### PR TITLE
Feature/price feed revert

### DIFF
--- a/contracts/lib/FundingLibrary.sol
+++ b/contracts/lib/FundingLibrary.sol
@@ -33,6 +33,7 @@ library FundingLibrary {
         fundingInfo.prevIndexPriceTimestamp = block.timestamp;
     }
 
+    // must not revert even if priceFeed is malicious
     function processFunding(MarketStructs.FundingInfo storage fundingInfo, ProcessFundingParams memory params)
         internal
         returns (int256 fundingRateX96)
@@ -41,12 +42,16 @@ library FundingLibrary {
         uint256 elapsedSec = currentTimestamp.sub(fundingInfo.prevIndexPriceTimestamp);
         if (elapsedSec == 0) return 0;
 
-        uint256 indexPriceBase = _getIndexPrice(params.priceFeedBase);
-        uint256 indexPriceQuote = _getIndexPrice(params.priceFeedQuote);
+        uint256 indexPriceBase = _getIndexPriceSafe(params.priceFeedBase);
+        uint256 indexPriceQuote = _getIndexPriceSafe(params.priceFeedQuote);
+        uint8 decimalsBase = _getDecimalsSafe(params.priceFeedBase);
+        uint8 decimalsQuote = _getDecimalsSafe(params.priceFeedQuote);
         if (
             (fundingInfo.prevIndexPriceBase == indexPriceBase && fundingInfo.prevIndexPriceQuote == indexPriceQuote) ||
             indexPriceBase == 0 ||
-            indexPriceQuote == 0
+            indexPriceQuote == 0 ||
+            decimalsBase == 255 ||
+            decimalsQuote == 255
         ) {
             return 0;
         }
@@ -54,13 +59,7 @@ library FundingLibrary {
         elapsedSec = Math.min(elapsedSec, params.maxElapsedSec);
 
         int256 premiumX96 =
-            _calcPremiumX96(
-                params.priceFeedBase,
-                params.priceFeedQuote,
-                indexPriceBase,
-                indexPriceQuote,
-                params.markPriceX96
-            );
+            _calcPremiumX96(decimalsBase, decimalsQuote, indexPriceBase, indexPriceQuote, params.markPriceX96);
 
         int256 maxPremiumX96 = FixedPoint96.Q96.mulRatio(params.maxPremiumRatio).toInt256();
         premiumX96 = (-maxPremiumX96).max(maxPremiumX96.min(premiumX96));
@@ -77,44 +76,58 @@ library FundingLibrary {
         uint256 base,
         uint256 quote
     ) internal view {
-        uint256 indexPriceBase = _getIndexPrice(priceFeedBase);
-        uint256 indexPriceQuote = _getIndexPrice(priceFeedQuote);
+        uint256 indexPriceBase = _getIndexPriceSafe(priceFeedBase);
+        uint256 indexPriceQuote = _getIndexPriceSafe(priceFeedQuote);
         require(indexPriceBase > 0, "FL_VILP: invalid base price");
         require(indexPriceQuote > 0, "FL_VILP: invalid quote price");
+        uint8 decimalsBase = _getDecimalsSafe(priceFeedBase);
+        uint8 decimalsQuote = _getDecimalsSafe(priceFeedQuote);
+        require(decimalsBase != 255, "FL_VILP: invalid base decimals");
+        require(decimalsQuote != 255, "FL_VILP: invalid quote decimals");
 
         uint256 markPriceX96 = FullMath.mulDiv(quote, FixedPoint96.Q96, base);
-        int256 premiumX96 =
-            _calcPremiumX96(priceFeedBase, priceFeedQuote, indexPriceBase, indexPriceQuote, markPriceX96);
+        int256 premiumX96 = _calcPremiumX96(decimalsBase, decimalsQuote, indexPriceBase, indexPriceQuote, markPriceX96);
 
         require(premiumX96.abs() <= FixedPoint96.Q96.mulRatio(1e5), "FL_VILP: too far from index");
     }
 
-    function _getIndexPrice(address priceFeed) private view returns (uint256) {
-        return priceFeed != address(0) ? IPerpdexPriceFeed(priceFeed).getPrice() : 1;
+    function _getIndexPriceSafe(address priceFeed) private view returns (uint256) {
+        if (priceFeed == address(0)) return 1; // indicate valid
+
+        bytes memory payload = abi.encodeWithSignature("getPrice()");
+        (bool success, bytes memory data) = address(priceFeed).staticcall(payload);
+        if (!success) return 0; // invalid
+
+        return abi.decode(data, (uint256));
     }
 
+    function _getDecimalsSafe(address priceFeed) private view returns (uint8) {
+        if (priceFeed == address(0)) return 0; // indicate valid
+
+        bytes memory payload = abi.encodeWithSignature("decimals()");
+        (bool success, bytes memory data) = address(priceFeed).staticcall(payload);
+        if (!success) return 255; // invalid
+
+        return abi.decode(data, (uint8));
+    }
+
+    // TODO: must not revert
     function _calcPremiumX96(
-        address priceFeedBase,
-        address priceFeedQuote,
+        uint8 decimalsBase,
+        uint8 decimalsQuote,
         uint256 indexPriceBase,
         uint256 indexPriceQuote,
         uint256 markPriceX96
     ) private view returns (int256 premiumX96) {
         uint256 priceRatioX96 = markPriceX96;
-        if (priceFeedBase != address(0)) {
-            priceRatioX96 = FullMath.mulDiv(
-                priceRatioX96,
-                10**IPerpdexPriceFeed(priceFeedBase).decimals(),
-                indexPriceBase
-            );
+
+        if (decimalsBase != 0 || indexPriceBase != 1) {
+            priceRatioX96 = FullMath.mulDiv(priceRatioX96, 10**decimalsBase, indexPriceBase);
         }
-        if (priceFeedQuote != address(0)) {
-            priceRatioX96 = FullMath.mulDiv(
-                priceRatioX96,
-                indexPriceQuote,
-                10**IPerpdexPriceFeed(priceFeedQuote).decimals()
-            );
+        if (decimalsQuote != 0 || indexPriceQuote != 1) {
+            priceRatioX96 = FullMath.mulDiv(priceRatioX96, indexPriceQuote, 10**decimalsQuote);
         }
+
         premiumX96 = priceRatioX96.toInt256().sub(FixedPoint96.Q96.toInt256());
     }
 }

--- a/contracts/lib/FundingLibrary.sol
+++ b/contracts/lib/FundingLibrary.sol
@@ -29,6 +29,8 @@ library FundingLibrary {
         uint32 rolloverSec;
     }
 
+    uint8 public constant MAX_DECIMALS = 77; // 10^MAX_DECIMALS < 2^256
+
     function initializeFunding(MarketStructs.FundingInfo storage fundingInfo) internal {
         fundingInfo.prevIndexPriceTimestamp = block.timestamp;
     }
@@ -50,8 +52,8 @@ library FundingLibrary {
             (fundingInfo.prevIndexPriceBase == indexPriceBase && fundingInfo.prevIndexPriceQuote == indexPriceQuote) ||
             indexPriceBase == 0 ||
             indexPriceQuote == 0 ||
-            decimalsBase == 255 ||
-            decimalsQuote == 255
+            decimalsBase > MAX_DECIMALS ||
+            decimalsQuote > MAX_DECIMALS
         ) {
             return 0;
         }
@@ -82,8 +84,8 @@ library FundingLibrary {
         require(indexPriceQuote > 0, "FL_VILP: invalid quote price");
         uint8 decimalsBase = _getDecimalsSafe(priceFeedBase);
         uint8 decimalsQuote = _getDecimalsSafe(priceFeedQuote);
-        require(decimalsBase != 255, "FL_VILP: invalid base decimals");
-        require(decimalsQuote != 255, "FL_VILP: invalid quote decimals");
+        require(decimalsBase <= MAX_DECIMALS, "FL_VILP: invalid base decimals");
+        require(decimalsQuote <= MAX_DECIMALS, "FL_VILP: invalid quote decimals");
 
         uint256 markPriceX96 = FullMath.mulDiv(quote, FixedPoint96.Q96, base);
         int256 premiumX96 = _calcPremiumX96(decimalsBase, decimalsQuote, indexPriceBase, indexPriceQuote, markPriceX96);

--- a/test/fundingLibrary/processFunding.test.ts
+++ b/test/fundingLibrary/processFunding.test.ts
@@ -118,6 +118,40 @@ describe("FundingLibrary processFunding", () => {
                 priceQuote: 0,
                 updated: false,
             },
+            {
+                title: "getPrice revert base",
+                prevIndexPriceBase: 2,
+                prevIndexPriceQuote: 1,
+                prevIndexPriceTimestamp: -1,
+                priceBase: "revert",
+                updated: false,
+            },
+            {
+                title: "getPrice revert quote",
+                prevIndexPriceBase: 1,
+                prevIndexPriceQuote: 3,
+                prevIndexPriceTimestamp: -1,
+                priceQuote: "revert",
+                updated: false,
+            },
+            {
+                title: "decimals revert base",
+                prevIndexPriceBase: 2,
+                prevIndexPriceQuote: 1,
+                prevIndexPriceTimestamp: -1,
+                priceBase: 1,
+                decimalsBase: "revert",
+                updated: false,
+            },
+            {
+                title: "decimals revert quote",
+                prevIndexPriceBase: 1,
+                prevIndexPriceQuote: 3,
+                prevIndexPriceTimestamp: -1,
+                priceQuote: 1,
+                decimalsQuote: "revert",
+                updated: false,
+            },
         ].forEach(test => {
             it(test.title, async () => {
                 const currentTimestamp = await getTimestamp()
@@ -127,11 +161,23 @@ describe("FundingLibrary processFunding", () => {
                     prevIndexPriceQuote: test.prevIndexPriceQuote,
                     prevIndexPriceTimestamp: currentTimestamp + 1000 + test.prevIndexPriceTimestamp,
                 })
-                if (test.priceBase !== void 0) {
+
+                if (test.priceBase === "revert") {
+                    await priceFeedBase.mock.getPrice.revertsWithReason("TEST: invalid base price")
+                } else if (test.priceBase !== void 0) {
                     await priceFeedBase.mock.getPrice.returns(test.priceBase)
                 }
-                if (test.priceQuote !== void 0) {
+                if (test.priceQuote === "revert") {
+                    await priceFeedQuote.mock.getPrice.revertsWithReason("TEST: invalid quote price")
+                } else if (test.priceQuote !== void 0) {
                     await priceFeedQuote.mock.getPrice.returns(test.priceQuote)
+                }
+
+                if (test.decimalsBase === "revert") {
+                    await priceFeedBase.mock.decimals.revertsWithReason("TEST: invalid base decimals")
+                }
+                if (test.decimalsQuote === "revert") {
+                    await priceFeedQuote.mock.decimals.revertsWithReason("TEST: invalid quote decimals")
                 }
 
                 await setNextTimestamp(currentTimestamp + 1000)

--- a/test/fundingLibrary/processFunding.test.ts
+++ b/test/fundingLibrary/processFunding.test.ts
@@ -152,6 +152,24 @@ describe("FundingLibrary processFunding", () => {
                 decimalsQuote: "revert",
                 updated: false,
             },
+            {
+                title: "decimals overflow base",
+                prevIndexPriceBase: 1,
+                prevIndexPriceQuote: 1,
+                prevIndexPriceTimestamp: -1,
+                priceBase: 2,
+                decimalsBase: 78,
+                updated: false,
+            },
+            {
+                title: "decimals overflow quote",
+                prevIndexPriceBase: 1,
+                prevIndexPriceQuote: 1,
+                prevIndexPriceTimestamp: -1,
+                priceQuote: 2,
+                decimalsQuote: 78,
+                updated: false,
+            },
         ].forEach(test => {
             it(test.title, async () => {
                 const currentTimestamp = await getTimestamp()
@@ -175,9 +193,13 @@ describe("FundingLibrary processFunding", () => {
 
                 if (test.decimalsBase === "revert") {
                     await priceFeedBase.mock.decimals.revertsWithReason("TEST: invalid base decimals")
+                } else if (test.decimalsBase !== void 0) {
+                    await priceFeedBase.mock.decimals.returns(test.decimalsBase)
                 }
                 if (test.decimalsQuote === "revert") {
                     await priceFeedQuote.mock.decimals.revertsWithReason("TEST: invalid quote decimals")
+                } else if (test.decimalsQuote !== void 0) {
+                    await priceFeedQuote.mock.decimals.returns(test.decimalsQuote)
                 }
 
                 await setNextTimestamp(currentTimestamp + 1000)

--- a/test/fundingLibrary/validateInitialLiquidityPrice.test.ts
+++ b/test/fundingLibrary/validateInitialLiquidityPrice.test.ts
@@ -59,6 +59,36 @@ describe("FundingLibrary", () => {
                 revertedWith: "FL_VILP: invalid quote price",
             },
             {
+                title: "getPrice revert base",
+                base: 1,
+                quote: 1,
+                priceBase: "revert",
+                revertedWith: "FL_VILP: invalid base price",
+            },
+            {
+                title: "getPrice revert quote",
+                base: 1,
+                quote: 1,
+                priceQuote: "revert",
+                revertedWith: "FL_VILP: invalid quote price",
+            },
+            {
+                title: "decimals revert base",
+                base: 1,
+                quote: 1,
+                priceBase: 1,
+                decimalsBase: "revert",
+                revertedWith: "FL_VILP: invalid base decimals",
+            },
+            {
+                title: "decimals revert quote",
+                base: 1,
+                quote: 1,
+                priceQuote: 1,
+                decimalsQuote: "revert",
+                revertedWith: "FL_VILP: invalid quote decimals",
+            },
+            {
                 title: "too high mark",
                 base: 100,
                 quote: 111,
@@ -105,11 +135,22 @@ describe("FundingLibrary", () => {
                 const pfBase = test.priceBase !== void 0 ? priceFeedBase.address : hre.ethers.constants.AddressZero
                 const pfQuote = test.priceQuote !== void 0 ? priceFeedQuote.address : hre.ethers.constants.AddressZero
 
-                if (test.priceBase !== void 0) {
+                if (test.priceBase === "revert") {
+                    await priceFeedBase.mock.getPrice.revertsWithReason("TEST: invalid base price")
+                } else if (test.priceBase !== void 0) {
                     await priceFeedBase.mock.getPrice.returns(test.priceBase)
                 }
-                if (test.priceQuote !== void 0) {
+                if (test.priceQuote === "revert") {
+                    await priceFeedQuote.mock.getPrice.revertsWithReason("TEST: invalid quote price")
+                } else if (test.priceQuote !== void 0) {
                     await priceFeedQuote.mock.getPrice.returns(test.priceQuote)
+                }
+
+                if (test.decimalsBase === "revert") {
+                    await priceFeedBase.mock.decimals.revertsWithReason("TEST: invalid base decimals")
+                }
+                if (test.decimalsQuote === "revert") {
+                    await priceFeedQuote.mock.decimals.revertsWithReason("TEST: invalid quote decimals")
                 }
 
                 const res = expect(fundingLibrary.validateInitialLiquidityPrice(pfBase, pfQuote, test.base, test.quote))

--- a/test/fundingLibrary/validateInitialLiquidityPrice.test.ts
+++ b/test/fundingLibrary/validateInitialLiquidityPrice.test.ts
@@ -73,6 +73,22 @@ describe("FundingLibrary", () => {
                 revertedWith: "FL_VILP: invalid quote price",
             },
             {
+                title: "decimals overflow base",
+                base: 1,
+                quote: 1,
+                priceBase: 1,
+                decimalsBase: 78,
+                revertedWith: "FL_VILP: invalid base decimals",
+            },
+            {
+                title: "decimals overflow quote",
+                base: 1,
+                quote: 1,
+                priceQuote: 1,
+                decimalsQuote: 78,
+                revertedWith: "FL_VILP: invalid quote decimals",
+            },
+            {
                 title: "decimals revert base",
                 base: 1,
                 quote: 1,
@@ -148,9 +164,13 @@ describe("FundingLibrary", () => {
 
                 if (test.decimalsBase === "revert") {
                     await priceFeedBase.mock.decimals.revertsWithReason("TEST: invalid base decimals")
+                } else if (test.decimalsBase !== void 0) {
+                    await priceFeedBase.mock.decimals.returns(test.decimalsBase)
                 }
                 if (test.decimalsQuote === "revert") {
                     await priceFeedQuote.mock.decimals.revertsWithReason("TEST: invalid quote decimals")
+                } else if (test.decimalsQuote !== void 0) {
+                    await priceFeedQuote.mock.decimals.returns(test.decimalsQuote)
                 }
 
                 const res = expect(fundingLibrary.validateInitialLiquidityPrice(pfBase, pfQuote, test.base, test.quote))


### PR DESCRIPTION
Changes

- Changed to not revert even if PriceFeed call is reverted

TODO (other PR)

- If PriceFeed returns a value that is too large, FullMath.mulDiv may overflow and revert. However, it is an edge case and even if it happens, it just stops, so ignore it.

### PR Reminders

Be ware of the followings

- [ ] implement deployment script for your changes in deployment repo
- [ ] add verification in hardhat simulation(000-prepare-simulation-check, 902-newMarket-check or 903-simulation-check) and system test(901-system-test) in deployment repo
- [ ] update change log
 
---

1. **Contract**: make sure the code follows our convention, ex: naming, explicit returns, etc.; if uncertain, discuss with others

2. **Test**: make sure tests can cover most normal and edge cases; if not, open follow-up tickets. Also, look out for failed tests and fix them!

3. **CHANGELOG.md**: update when external interfaces are changed

4. Workflow: 
    - Github: assign the pr to yourself; if pairing, can merge directly; else, assign someone to help review
    - Asana: assign the corresponding ticket to yourself and leave the pr link on it for easier follow-ups
    - Discord: if someone is mentioned in this pr, tag on Discord