### PR TITLE
prevent taker liquidation when maker position exist

### DIFF
--- a/contracts/lib/TakerLibrary.sol
+++ b/contracts/lib/TakerLibrary.sol
@@ -68,6 +68,10 @@ library TakerLibrary {
             require(response.isLiquidation, "TL_OP: enough mm");
         }
 
+        if (response.isLiquidation) {
+            require(accountInfo.makerInfos[params.market].liquidity == 0, "TL_OP: no maker when liquidation");
+        }
+
         int256 takerBaseBefore = accountInfo.takerInfos[params.market].baseBalanceShare;
 
         (response.base, response.quote, response.realizedPnl, response.protocolFee) = _doSwap(
@@ -164,6 +168,10 @@ library TakerLibrary {
             require(isLiquidation, "TL_OPD: enough mm");
         }
 
+        if (isLiquidation) {
+            require(accountInfo.makerInfos[params.market].liquidity == 0, "TL_OPD: no maker when liq");
+        }
+
         oppositeAmount;
         if (params.protocolFeeRatio == 0) {
             oppositeAmount = IPerpdexMarketMinimum(params.market).previewSwap(
@@ -198,6 +206,10 @@ library TakerLibrary {
         bool isLiquidation = !AccountLibrary.hasEnoughMaintenanceMargin(accountInfo, mmRatio);
 
         if (!isSelf && !isLiquidation) {
+            return 0;
+        }
+
+        if (isLiquidation && accountInfo.makerInfos[market].liquidity != 0) {
             return 0;
         }
 

--- a/test/perpdexExchange/maxOpenPosition.test.ts
+++ b/test/perpdexExchange/maxOpenPosition.test.ts
@@ -115,6 +115,23 @@ describe("PerpdexExchange maxTrade", () => {
                 maxAmount: 252,
             },
             {
+                title: "long with maker position",
+                isBaseToQuote: false,
+                isExactInput: true,
+                protocolFeeRatio: 0,
+                collateralBalance: 100,
+                takerInfo: {
+                    baseBalanceShare: 0,
+                    quoteBalance: 0,
+                },
+                makerInfo: {
+                    liquidity: 1,
+                    cumBaseSharePerLiquidityX96: Q96,
+                    cumQuotePerLiquidityX96: Q96,
+                },
+                maxAmount: 246,
+            },
+            {
                 title: "not liquidatable because enough mm",
                 notSelf: true,
                 isBaseToQuote: false,
@@ -124,6 +141,24 @@ describe("PerpdexExchange maxTrade", () => {
                 takerInfo: {
                     baseBalanceShare: 100,
                     quoteBalance: -100,
+                },
+                maxAmount: 0,
+            },
+            {
+                title: "not liquidatable because maker position exist",
+                notSelf: true,
+                isBaseToQuote: false,
+                isExactInput: true,
+                protocolFeeRatio: 0,
+                collateralBalance: 4,
+                takerInfo: {
+                    baseBalanceShare: 100,
+                    quoteBalance: -100,
+                },
+                makerInfo: {
+                    liquidity: 1,
+                    cumBaseSharePerLiquidityX96: Q96,
+                    cumQuotePerLiquidityX96: Q96,
                 },
                 maxAmount: 0,
             },
@@ -205,6 +240,9 @@ describe("PerpdexExchange maxTrade", () => {
                     )
 
                     await exchange.setTakerInfo(alice.address, market.address, test.takerInfo)
+                    if (test.makerInfo) {
+                        await exchange.setMakerInfo(alice.address, market.address, test.makerInfo)
+                    }
 
                     if (test.isMarketAllowed !== void 0) {
                         await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)

--- a/test/perpdexExchange/openPosition.test.ts
+++ b/test/perpdexExchange/openPosition.test.ts
@@ -269,6 +269,33 @@ describe("PerpdexExchange trade", () => {
                 insuranceFund: 0,
             },
             {
+                title: "long with maker position",
+                isBaseToQuote: false,
+                isExactInput: true,
+                amount: 100,
+                oppositeAmountBound: 0,
+                protocolFeeRatio: 0,
+                collateralBalance: 100,
+                takerInfo: {
+                    baseBalanceShare: 0,
+                    quoteBalance: 0,
+                },
+                makerInfo: {
+                    liquidity: 1,
+                    cumBaseSharePerLiquidityX96: Q96,
+                    cumQuotePerLiquidityX96: Q96,
+                },
+                outputBase: 99,
+                outputQuote: -100,
+                afterCollateralBalance: 100,
+                afterTakerInfo: {
+                    baseBalanceShare: 99,
+                    quoteBalance: -100,
+                },
+                protocolFee: 0,
+                insuranceFund: 0,
+            },
+            {
                 title: "not liquidatable because enough mm",
                 notSelf: true,
                 isBaseToQuote: false,
@@ -283,6 +310,27 @@ describe("PerpdexExchange trade", () => {
                 },
                 revertedWith: "TL_OP: enough mm",
                 revertedWithDry: "TL_OPD: enough mm",
+            },
+            {
+                title: "not liquidatable because maker position exist",
+                notSelf: true,
+                isBaseToQuote: false,
+                isExactInput: true,
+                amount: 100,
+                oppositeAmountBound: 0,
+                protocolFeeRatio: 0,
+                collateralBalance: 4,
+                takerInfo: {
+                    baseBalanceShare: 100,
+                    quoteBalance: -100,
+                },
+                makerInfo: {
+                    liquidity: 1,
+                    cumBaseSharePerLiquidityX96: Q96,
+                    cumQuotePerLiquidityX96: Q96,
+                },
+                revertedWith: "TL_OP: no maker when liquidation",
+                revertedWithDry: "TL_OPD: no maker when liq",
             },
             {
                 title: "open is not allowed when liquidation",
@@ -537,6 +585,9 @@ describe("PerpdexExchange trade", () => {
                     )
 
                     await exchange.setTakerInfo(alice.address, market.address, test.takerInfo)
+                    if (test.makerInfo) {
+                        await exchange.setMakerInfo(alice.address, market.address, test.makerInfo)
+                    }
 
                     if (test.isMarketAllowed !== void 0) {
                         await exchange.connect(owner).setIsMarketAllowed(market.address, test.isMarketAllowed)


### PR DESCRIPTION
solution

- prevent taker liquidation when maker position exist

problem

- liquidator can liquidate only taker position without closing maker position
  - "L3: Cancel excess orders and liquidate are separate actions" in https://github.com/perpetual-protocol/perp-curie-contract/blob/2e183dcd8c991801819439629aa7f47718b605b9/audits/2021.12.21-dedaub.pdf 

### PR Reminders

Be ware of the followings

- [ ] implement deployment script for your changes in deployment repo
- [ ] add verification in hardhat simulation(000-prepare-simulation-check, 902-newMarket-check or 903-simulation-check) and system test(901-system-test) in deployment repo
- [ ] update change log
 
---

1. **Contract**: make sure the code follows our convention, ex: naming, explicit returns, etc.; if uncertain, discuss with others

2. **Test**: make sure tests can cover most normal and edge cases; if not, open follow-up tickets. Also, look out for failed tests and fix them!

3. **CHANGELOG.md**: update when external interfaces are changed

4. Workflow: 
    - Github: assign the pr to yourself; if pairing, can merge directly; else, assign someone to help review
    - Asana: assign the corresponding ticket to yourself and leave the pr link on it for easier follow-ups
    - Discord: if someone is mentioned in this pr, tag on Discord