### PR TITLE
add adative fee

### DIFF
--- a/contracts/lib/MakerOrderBookLibrary.sol
+++ b/contracts/lib/MakerOrderBookLibrary.sol
@@ -94,11 +94,11 @@ library MakerOrderBookLibrary {
     }
 
     function makeUserData(uint256 priceX96) internal pure returns (uint128) {
-        return (priceX96 >> 32).toUint128();
+        return priceX96.toUint128();
     }
 
-    function userDataToPriceX96(uint128 userData) internal pure returns (uint256) {
-        return userData << 32;
+    function userDataToPriceX96(uint128 userData) internal pure returns (uint128) {
+        return userData;
     }
 
     function lessThan(
@@ -107,8 +107,8 @@ library MakerOrderBookLibrary {
         uint40 key0,
         uint40 key1
     ) private view returns (bool) {
-        uint256 price0 = userDataToPriceX96(tree.nodes[key0].userData);
-        uint256 price1 = userDataToPriceX96(tree.nodes[key1].userData);
+        uint128 price0 = userDataToPriceX96(tree.nodes[key0].userData);
+        uint128 price1 = userDataToPriceX96(tree.nodes[key1].userData);
         if (price0 == price1) {
             return key0 < key1; // time priority
         }

--- a/contracts/lib/MarketStructs.sol
+++ b/contracts/lib/MarketStructs.sol
@@ -58,4 +58,17 @@ library MarketStructs {
         uint48 seqExecutionId;
         mapping(uint48 => ExecutionInfo) executionInfos;
     }
+
+    struct PoolFeeInfo {
+        uint256 atrX96;
+        uint256 referenceTimestamp;
+        uint256 currentHighX96;
+        uint256 currentLowX96;
+    }
+
+    struct PoolFeeConfig {
+        uint24 fixedFeeRatio;
+        uint24 atrFeeRatio;
+        uint32 atrEmaBlocks;
+    }
 }

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -128,11 +128,11 @@ library OrderBookLibrary {
     }
 
     function makeUserData(uint256 priceX96) internal pure returns (uint128) {
-        return (priceX96 >> 32).toUint128();
+        return priceX96.toUint128();
     }
 
-    function userDataToPriceX96(uint128 userData) internal pure returns (uint256) {
-        return userData << 32;
+    function userDataToPriceX96(uint128 userData) internal pure returns (uint128) {
+        return userData;
     }
 
     function lessThan(
@@ -141,8 +141,8 @@ library OrderBookLibrary {
         uint40 key0,
         uint40 key1
     ) private view returns (bool) {
-        uint256 price0 = userDataToPriceX96(tree.nodes[key0].userData);
-        uint256 price1 = userDataToPriceX96(tree.nodes[key1].userData);
+        uint128 price0 = userDataToPriceX96(tree.nodes[key0].userData);
+        uint128 price1 = userDataToPriceX96(tree.nodes[key1].userData);
         if (price0 == price1) {
             return key0 < key1; // time priority
         }
@@ -213,7 +213,7 @@ library OrderBookLibrary {
     }
 
     function _getQuote(MarketStructs.OrderBookSideInfo storage info, uint40 key) private view returns (uint256) {
-        uint256 priceX96 = userDataToPriceX96(info.tree.nodes[key].userData);
+        uint128 priceX96 = userDataToPriceX96(info.tree.nodes[key].userData);
         return Math.mulDiv(info.orderInfos[key].base, priceX96, FixedPoint96.Q96);
     }
 
@@ -279,7 +279,7 @@ library OrderBookLibrary {
 
     // to avoid stack too deep
     struct PreviewSwapLocalVars {
-        uint256 priceX96;
+        uint128 priceX96;
         uint256 sharePriceX96;
         uint256 amountPool;
         uint40 left;
@@ -381,7 +381,7 @@ library OrderBookLibrary {
         uint40 key = info.tree.root;
 
         while (key != 0) {
-            uint256 price = userDataToPriceX96(info.tree.nodes[key].userData);
+            uint128 price = userDataToPriceX96(info.tree.nodes[key].userData);
             uint40 left = info.tree.nodes[key].left;
             if (isBid ? price >= priceBoundX96 : price <= priceBoundX96) {
                 // key - right is more gas efficient than left + key

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -115,6 +115,12 @@ library OrderBookLibrary {
         );
     }
 
+    function getBestPriceX96(MarketStructs.OrderBookSideInfo storage info) external view returns (uint256) {
+        if (info.tree.root == 0) return 0;
+        uint40 key = info.tree.first();
+        return userDataToPriceX96(info.tree.nodes[key].userData);
+    }
+
     function isFullyExecuted(MarketStructs.OrderBookSideInfo storage info, uint40 key) private view returns (uint48) {
         uint40 root = info.tree.root;
         while (key != 0 && key != root) {

--- a/contracts/lib/PerpMath.sol
+++ b/contracts/lib/PerpMath.sol
@@ -65,6 +65,10 @@ library PerpMath {
         return Math.mulDiv(value, ratio, 1e6);
     }
 
+    function mulRatioRoundingUp(uint256 value, uint24 ratio) internal pure returns (uint256) {
+        return Math.mulDiv(value, ratio, 1e6, Math.Rounding.Up);
+    }
+
     function divRatio(uint256 value, uint24 ratio) internal pure returns (uint256) {
         return Math.mulDiv(value, 1e6, ratio);
     }

--- a/contracts/lib/PoolFeeLibrary.sol
+++ b/contracts/lib/PoolFeeLibrary.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import { FixedPoint96 } from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
+import { PerpMath } from "./PerpMath.sol";
+import { MarketStructs } from "./MarketStructs.sol";
+
+library PoolFeeLibrary {
+    using PerpMath for uint256;
+    using SafeCast for uint256;
+    using SafeMath for uint256;
+
+    function update(
+        MarketStructs.PoolFeeInfo storage poolFeeInfo,
+        uint32 atrEmaBlocks,
+        uint256 prevPriceX96,
+        uint256 currentPriceX96
+    ) internal {
+        uint256 currentTimestamp = block.timestamp;
+
+        if (currentTimestamp <= poolFeeInfo.referenceTimestamp) {
+            poolFeeInfo.currentHighX96 = Math.max(poolFeeInfo.currentHighX96, currentPriceX96);
+            poolFeeInfo.currentLowX96 = Math.min(poolFeeInfo.currentLowX96, currentPriceX96);
+        } else {
+            poolFeeInfo.referenceTimestamp = currentTimestamp;
+            poolFeeInfo.atrX96 = _calculateAtrX96(poolFeeInfo, atrEmaBlocks);
+            poolFeeInfo.currentHighX96 = Math.max(prevPriceX96, currentPriceX96);
+            poolFeeInfo.currentLowX96 = Math.min(prevPriceX96, currentPriceX96);
+        }
+    }
+
+    function feeRatio(MarketStructs.PoolFeeInfo storage poolFeeInfo, MarketStructs.PoolFeeConfig memory config)
+        internal
+        view
+        returns (uint24)
+    {
+        uint256 atrX96 = _calculateAtrX96(poolFeeInfo, config.atrEmaBlocks);
+        return Math.mulDiv(config.atrFeeRatio, atrX96, FixedPoint96.Q96).add(config.fixedFeeRatio).toUint24();
+    }
+
+    function _calculateAtrX96(MarketStructs.PoolFeeInfo storage poolFeeInfo, uint32 atrEmaBlocks)
+        private
+        view
+        returns (uint256)
+    {
+        if (poolFeeInfo.currentLowX96 == 0) return 0;
+        uint256 trX96 =
+            Math.mulDiv(poolFeeInfo.currentHighX96, FixedPoint96.Q96, poolFeeInfo.currentLowX96).sub(FixedPoint96.Q96);
+        uint256 denominator = atrEmaBlocks + 1;
+        return Math.mulDiv(poolFeeInfo.atrX96, atrEmaBlocks, denominator).add(trX96.div(denominator));
+    }
+}

--- a/contracts/lib/PoolLibrary.sol
+++ b/contracts/lib/PoolLibrary.sol
@@ -213,6 +213,16 @@ library PoolLibrary {
         return Math.sqrt(b.mul(b).add(cNeg.mul(4))).sub(b).div(2);
     }
 
+    function getAskPriceX96(uint256 priceX96, uint24 feeRatio) internal pure returns (uint256) {
+        uint24 oneSubFeeRatio = PerpMath.subRatio(1e6, feeRatio);
+        return priceX96.divRatio(oneSubFeeRatio);
+    }
+
+    function getBidPriceX96(uint256 priceX96, uint24 feeRatio) internal pure returns (uint256) {
+        uint24 oneSubFeeRatio = PerpMath.subRatio(1e6, feeRatio);
+        return priceX96.mulRatioRoundingUp(oneSubFeeRatio);
+    }
+
     // must not revert
     // Trade until the trade price including fee (dy/dx) reaches priceBoundX96
     // not pool price (y/x)

--- a/contracts/test/TestPerpdexMarket.sol
+++ b/contracts/test/TestPerpdexMarket.sol
@@ -39,6 +39,10 @@ contract TestPerpdexMarket is PerpdexMarket {
         priceLimitInfo = value;
     }
 
+    function setPoolFeeInfo(MarketStructs.PoolFeeInfo memory value) external {
+        poolFeeInfo = value;
+    }
+
     function getLockedLiquidityInfo() external view returns (int256 base, int256 accountValue) {
         uint256 liquidity = PoolLibrary.MINIMUM_LIQUIDITY;
 

--- a/contracts/test/TestPoolFeeLibrary.sol
+++ b/contracts/test/TestPoolFeeLibrary.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import { PoolFeeLibrary } from "../lib/PoolFeeLibrary.sol";
+import { MarketStructs } from "../lib/MarketStructs.sol";
+
+contract TestPoolFeeLibrary {
+    MarketStructs.PoolFeeInfo public poolFeeInfo;
+
+    function update(
+        MarketStructs.PoolFeeInfo memory poolFeeInfoArg,
+        uint32 atrEmaBlocks,
+        uint256 prevPriceX96,
+        uint256 currentPriceX96
+    ) external {
+        poolFeeInfo = poolFeeInfoArg;
+        PoolFeeLibrary.update(poolFeeInfo, atrEmaBlocks, prevPriceX96, currentPriceX96);
+    }
+}

--- a/test/perpdexExchange/fixtures.ts
+++ b/test/perpdexExchange/fixtures.ts
@@ -3,7 +3,6 @@ import { TestPerpdexExchange, TestPerpdexMarket, TestERC20 } from "../../typecha
 import { BigNumber, Wallet } from "ethers"
 import IPerpdexPriceFeedJson from "../../artifacts/contracts/interfaces/IPerpdexPriceFeed.sol/IPerpdexPriceFeed.json"
 import { MockContract } from "ethereum-waffle"
-import _ from "lodash"
 
 export interface PerpdexExchangeFixture {
     perpdexExchange: TestPerpdexExchange
@@ -33,7 +32,7 @@ const Q96 = BigNumber.from(2).pow(96)
 export function createPerpdexExchangeFixture(
     params: Params = {},
 ): (wallets, provider) => Promise<PerpdexExchangeFixture> {
-    params = _.extend({ linear: false, isMarketAllowed: false, initPool: false, marketCount: 1 }, params)
+    params = { linear: false, isMarketAllowed: false, initPool: false, marketCount: 1, ...params }
     return async ([owner, alice, bob, carol], provider): Promise<PerpdexExchangeFixture> => {
         let settlementToken = hre.ethers.constants.AddressZero
         let USDC
@@ -89,7 +88,11 @@ export function createPerpdexExchangeFixture(
                 ethers.constants.AddressZero,
             )) as TestPerpdexMarket
 
-            await perpdexMarkets[i].connect(owner).setPoolFeeRatio(0)
+            await perpdexMarkets[i].connect(owner).setPoolFeeConfig({
+                fixedFeeRatio: 0,
+                atrFeeRatio: 0,
+                atrEmaBlocks: 1,
+            })
             await perpdexMarkets[i].connect(owner).setFundingMaxPremiumRatio(0)
 
             if (params.isMarketAllowed) {

--- a/test/perpdexExchange/openPositionConsistency.test.ts
+++ b/test/perpdexExchange/openPositionConsistency.test.ts
@@ -68,7 +68,11 @@ describe("PerpdexExchange trade consistency", () => {
                             let amount
 
                             beforeEach(async () => {
-                                await market.connect(owner).setPoolFeeRatio(fee)
+                                await market.connect(owner).setPoolFeeConfig({
+                                    fixedFeeRatio: fee,
+                                    atrFeeRatio: 0,
+                                    atrEmaBlocks: 1,
+                                })
                                 await exchange.connect(owner).setProtocolFeeRatio(protocolFee)
 
                                 await exchange.setAccountInfo(

--- a/test/perpdexMarket/fee.test.ts
+++ b/test/perpdexMarket/fee.test.ts
@@ -1,0 +1,246 @@
+import { expect } from "chai"
+import { waffle } from "hardhat"
+import { TestPerpdexMarket } from "../../typechain"
+import { createPerpdexMarketFixture } from "./fixtures"
+import { BigNumber, Wallet } from "ethers"
+import { getTimestamp, setNextTimestamp } from "../helper/time"
+
+describe("PerpdexMarket fee", () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let market: TestPerpdexMarket
+    let owner: Wallet
+    let alice: Wallet
+    let exchange: Wallet
+
+    const Q96 = BigNumber.from(2).pow(96)
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexMarketFixture())
+        market = fixture.perpdexMarket
+        owner = fixture.owner
+        alice = fixture.alice
+        exchange = fixture.exchange
+    })
+
+    describe("feeRatio", () => {
+        ;[
+            {
+                title: "zero",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: 0,
+                    currentLowX96: 0,
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 0,
+                    atrEmaBlocks: 0,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 0,
+            },
+            {
+                title: "fixed fee",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: 0,
+                    currentLowX96: 0,
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 1e4,
+                    atrFeeRatio: 0,
+                    atrEmaBlocks: 0,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 1e4,
+            },
+            {
+                title: "price limit",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: 0,
+                    currentLowX96: 0,
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 1e4,
+                    atrFeeRatio: 0,
+                    atrEmaBlocks: 0,
+                },
+                priceLimitNormalOrderRatio: 1e4,
+                feeRatio: 5e3,
+            },
+            {
+                title: "adaptive no memory",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: Q96.mul(2).mul(101).div(100),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 1e6,
+                    atrEmaBlocks: 0,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 1e4 - 1, // rounding error
+            },
+            {
+                title: "adaptive no memory 2",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: Q96.mul(2).mul(101).div(100),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 2e6,
+                    atrEmaBlocks: 0,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 2e4 - 1, // rounding error
+            },
+            {
+                title: "adaptive ema",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: Q96.mul(2).mul(101).div(100),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 1e6,
+                    atrEmaBlocks: 1,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 5e3 - 1, // rounding error
+            },
+            {
+                title: "adaptive ema 2",
+                poolFeeInfo: {
+                    atrX96: Q96.mul(1).div(100),
+                    currentHighX96: Q96.mul(2).mul(101).div(100),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 1e6,
+                    atrEmaBlocks: 1,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 1e4 - 1, // rounding error
+            },
+            {
+                title: "adaptive ema 3",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: Q96.mul(2).mul(101).div(100),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 1e6,
+                    atrEmaBlocks: 3,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 25e2 - 1, // rounding error
+            },
+            {
+                title: "adaptive ema 4",
+                poolFeeInfo: {
+                    atrX96: Q96.mul(1).div(100),
+                    currentHighX96: Q96.mul(2),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 0,
+                    atrFeeRatio: 1e6,
+                    atrEmaBlocks: 3,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 75e2 - 1, // rounding error
+            },
+            {
+                title: "adaptive ema + fixed fee",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    currentHighX96: Q96.mul(2).mul(101).div(100),
+                    currentLowX96: Q96.mul(2),
+                },
+                poolFeeConfig: {
+                    fixedFeeRatio: 1e4,
+                    atrFeeRatio: 1e6,
+                    atrEmaBlocks: 1,
+                },
+                priceLimitNormalOrderRatio: 10e4,
+                feeRatio: 15e3 - 1, // rounding error
+            },
+        ].forEach(test => {
+            describe(test.title, () => {
+                ;[-1, 0, 1].forEach(async referenceTimestamp => {
+                    const title = {
+                        "-1": "past",
+                        "0": "current",
+                        "1": "future",
+                    }[referenceTimestamp]
+
+                    it(title, async () => {
+                        const currentTimestamp = await getTimestamp()
+                        const nextTimeStamp = currentTimestamp + 1000
+                        await market.setPoolFeeInfo({
+                            ...test.poolFeeInfo,
+                            referenceTimestamp: nextTimeStamp + referenceTimestamp,
+                        })
+                        await market.setPoolFeeConfig(test.poolFeeConfig)
+                        await market.setPriceLimitConfig({
+                            normalOrderRatio: test.priceLimitNormalOrderRatio,
+                            liquidationRatio: test.priceLimitNormalOrderRatio,
+                            emaNormalOrderRatio: test.priceLimitNormalOrderRatio,
+                            emaLiquidationRatio: test.priceLimitNormalOrderRatio,
+                            emaSec: 0,
+                        })
+                        await setNextTimestamp(nextTimeStamp, true)
+
+                        expect(await market.feeRatio()).to.eq(test.feeRatio)
+                    })
+                })
+            })
+        })
+    })
+
+    describe("update after swap", () => {
+        it("normal", async () => {
+            const currentTimestamp = await getTimestamp()
+            const nextTimeStamp = currentTimestamp + 1000
+            await market.connect(exchange).addLiquidity(10000, 10000)
+            await market.setPoolFeeInfo({
+                atrX96: 0,
+                referenceTimestamp: nextTimeStamp - 1,
+                currentHighX96: 1,
+                currentLowX96: 1,
+            })
+            await market.setPoolFeeConfig({
+                fixedFeeRatio: 0,
+                atrFeeRatio: 1e6,
+                atrEmaBlocks: 1,
+            })
+            await market.setPriceLimitConfig({
+                normalOrderRatio: 1e5,
+                liquidationRatio: 1e5,
+                emaNormalOrderRatio: 1e5,
+                emaLiquidationRatio: 1e5,
+                emaSec: 0,
+            })
+            await setNextTimestamp(nextTimeStamp)
+            await market.connect(exchange).swap(false, true, 100, false)
+
+            const info = await market.poolFeeInfo()
+            expect(info.atrX96).to.eq(0)
+            expect(info.referenceTimestamp).to.eq(nextTimeStamp)
+            expect(info.currentHighX96).to.eq(await market.getShareMarkPriceX96())
+            expect(info.currentHighX96).to.eq(BigNumber.from("80820567760233290545883637854"))
+            expect(info.currentLowX96).to.eq(Q96)
+        })
+    })
+})

--- a/test/perpdexMarket/fixtures.ts
+++ b/test/perpdexMarket/fixtures.ts
@@ -3,7 +3,6 @@ import { TestPerpdexMarket } from "../../typechain"
 import IPerpdexPriceFeedJson from "../../artifacts/contracts/interfaces/IPerpdexPriceFeed.sol/IPerpdexPriceFeed.json"
 import { MockContract } from "ethereum-waffle"
 import { BigNumber, Wallet } from "ethers"
-import _ from "lodash"
 
 interface PerpdexMarketFixture {
     perpdexMarket: TestPerpdexMarket
@@ -20,7 +19,7 @@ interface Params {
 }
 
 export function createPerpdexMarketFixture(params: Params = {}): (wallets, provider) => Promise<PerpdexMarketFixture> {
-    params = _.extend({ skipConfig: false }, params)
+    params = { skipConfig: false, ...params }
     return async ([owner, alice, bob, exchange], provider): Promise<PerpdexMarketFixture> => {
         const priceFeed = await waffle.deployMockContract(owner, IPerpdexPriceFeedJson.abi)
         await priceFeed.mock.getPrice.returns(BigNumber.from(10).pow(18))
@@ -42,7 +41,11 @@ export function createPerpdexMarketFixture(params: Params = {}): (wallets, provi
         )) as TestPerpdexMarket
 
         if (!params.skipConfig) {
-            await perpdexMarket.connect(owner).setPoolFeeRatio(0)
+            await perpdexMarket.connect(owner).setPoolFeeConfig({
+                fixedFeeRatio: 0,
+                atrFeeRatio: 0,
+                atrEmaBlocks: 1,
+            })
             await perpdexMarket.connect(owner).setFundingMaxPremiumRatio(0)
         }
 

--- a/test/perpdexMarket/getQuote.test.ts
+++ b/test/perpdexMarket/getQuote.test.ts
@@ -1,0 +1,132 @@
+import { expect } from "chai"
+import { waffle } from "hardhat"
+import { TestPerpdexMarket } from "../../typechain"
+import { createPerpdexMarketFixture } from "./fixtures"
+import { BigNumber, Wallet } from "ethers"
+
+describe("PerpdexMarket getQuote", () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let market: TestPerpdexMarket
+    let exchange: Wallet
+
+    const Q96 = BigNumber.from(2).pow(96)
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexMarketFixture())
+        market = fixture.perpdexMarket
+        exchange = fixture.exchange
+    })
+
+    describe("various cases", () => {
+        ;[
+            {
+                title: "empty",
+                base: 0,
+                quote: 0,
+                fixedFeeRatio: 0,
+                askPriceX96: 0,
+                bidPriceX96: 0,
+            },
+            {
+                title: "pool only without fee",
+                base: 10000,
+                quote: 10000,
+                fixedFeeRatio: 0,
+                askPriceX96: Q96,
+                bidPriceX96: Q96,
+            },
+            {
+                title: "pool only with fee",
+                base: 10000,
+                quote: 10000,
+                fixedFeeRatio: 1e4,
+                askPriceX96: Q96.mul(100).div(99),
+                bidPriceX96: Q96.mul(99).div(100).add(1),
+            },
+            {
+                title: "pool spread is larger than order book",
+                base: 10000,
+                quote: 10000,
+                fixedFeeRatio: 1e4,
+                orderBookAsk: Q96.add(1),
+                orderBookBid: Q96.sub(1),
+                askPriceX96: Q96.add(1),
+                bidPriceX96: Q96.sub(1),
+            },
+            {
+                title: "pool spread is smaller than order book",
+                base: 10000,
+                quote: 10000,
+                fixedFeeRatio: 1e4,
+                orderBookAsk: Q96.mul(2),
+                orderBookBid: Q96.div(2),
+                askPriceX96: Q96.mul(100).div(99),
+                bidPriceX96: Q96.mul(99).div(100).add(1),
+            },
+        ].forEach(test => {
+            describe(test.title, async () => {
+                beforeEach(async () => {
+                    await market.setPoolInfo({
+                        base: test.base,
+                        quote: test.quote,
+                        totalLiquidity: (test.base * test.quote) ** 0.5,
+                        cumBasePerLiquidityX96: 0,
+                        cumQuotePerLiquidityX96: 0,
+                        baseBalancePerShareX96: Q96,
+                    })
+                    await market.setPoolFeeConfig({
+                        fixedFeeRatio: test.fixedFeeRatio,
+                        atrFeeRatio: 0,
+                        atrEmaBlocks: 1,
+                    })
+                    if (test.orderBookAsk) {
+                        await market.connect(exchange).createLimitOrder(false, 1, test.orderBookAsk)
+                    }
+                    if (test.orderBookBid) {
+                        await market.connect(exchange).createLimitOrder(true, 1, test.orderBookBid)
+                    }
+                })
+
+                it("askPriceX96", async () => {
+                    expect(await market.getAskPriceX96()).to.eq(test.askPriceX96)
+                })
+
+                it("bidPriceX96", async () => {
+                    expect(await market.getBidPriceX96()).to.eq(test.bidPriceX96)
+                })
+            })
+        })
+    })
+
+    describe("consistency with maxSwapByPrice", () => {
+        beforeEach(async () => {
+            await market.setPoolInfo({
+                base: Q96.shl(16),
+                quote: Q96.shl(16),
+                totalLiquidity: Q96.shl(16),
+                cumBasePerLiquidityX96: 0,
+                cumQuotePerLiquidityX96: 0,
+                baseBalancePerShareX96: Q96,
+            })
+            await market.setPoolFeeConfig({
+                fixedFeeRatio: 1e4,
+                atrFeeRatio: 0,
+                atrEmaBlocks: 1,
+            })
+        })
+
+        it("askPriceX96", async () => {
+            const ask = await market.getAskPriceX96()
+            expect(await market.maxSwapByPrice(false, true, ask)).to.eq(0)
+            expect(await market.maxSwapByPrice(false, true, ask.add(1))).to.gt(0)
+        })
+
+        it("bidPriceX96", async () => {
+            const bid = await market.getBidPriceX96()
+            expect(await market.maxSwapByPrice(true, true, bid)).to.eq(0)
+            expect(await market.maxSwapByPrice(true, true, bid.sub(1))).to.gt(0)
+        })
+    })
+})

--- a/test/perpdexMarket/maxSwap.test.ts
+++ b/test/perpdexMarket/maxSwap.test.ts
@@ -40,7 +40,11 @@ describe("PerpdexMarket maxSwap", () => {
 
     describe("with fee, without funding", () => {
         beforeEach(async () => {
-            await market.connect(owner).setPoolFeeRatio(1e4)
+            await market.connect(owner).setPoolFeeConfig({
+                fixedFeeRatio: 1e4,
+                atrFeeRatio: 0,
+                atrEmaBlocks: 1,
+            })
             await market.connect(exchange).addLiquidity(10000, 10000)
         })
         ;[

--- a/test/perpdexMarket/maxSwapByPrice.test.ts
+++ b/test/perpdexMarket/maxSwapByPrice.test.ts
@@ -42,7 +42,11 @@ describe("PerpdexMarket maxSwapByPrice", () => {
 
     describe("with fee, without funding", () => {
         beforeEach(async () => {
-            await market.connect(owner).setPoolFeeRatio(5e4)
+            await market.connect(owner).setPoolFeeConfig({
+                fixedFeeRatio: 5e4,
+                atrFeeRatio: 0,
+                atrEmaBlocks: 1,
+            })
             await market.connect(exchange).addLiquidity(10000, 10000)
         })
         ;[

--- a/test/perpdexMarket/swap.test.ts
+++ b/test/perpdexMarket/swap.test.ts
@@ -52,7 +52,11 @@ describe("PerpdexMarket swap", () => {
 
     describe("with fee, without funding", () => {
         beforeEach(async () => {
-            await market.connect(owner).setPoolFeeRatio(1e4)
+            await market.connect(owner).setPoolFeeConfig({
+                fixedFeeRatio: 1e4,
+                atrFeeRatio: 0,
+                atrEmaBlocks: 1,
+            })
             await market.connect(exchange).addLiquidity(10000, 10000)
         })
         ;[

--- a/test/perpdexMarket/swapConsistency.test.ts
+++ b/test/perpdexMarket/swapConsistency.test.ts
@@ -41,7 +41,11 @@ describe("PerpdexMarket swap consistency", () => {
                     describe(`fee ${fee} isBaseToQuote ${isBaseToQuote} isExactInput ${isExactInput} isLiquidation ${isLiquidation}`, () => {
                         beforeEach(async () => {
                             await market.connect(exchange).addLiquidity(initialPoolAmount, initialPoolAmount)
-                            await market.connect(owner).setPoolFeeRatio(fee)
+                            await market.connect(owner).setPoolFeeConfig({
+                                fixedFeeRatio: fee,
+                                atrFeeRatio: 0,
+                                atrEmaBlocks: 1,
+                            })
                         })
 
                         it("swap revert condition with maxSwap", async () => {

--- a/test/poolFeeLibrary/fixtures.ts
+++ b/test/poolFeeLibrary/fixtures.ts
@@ -1,0 +1,17 @@
+import { ethers, waffle } from "hardhat"
+import { TestPoolFeeLibrary } from "../../typechain"
+
+interface PoolFeeLibraryFixture {
+    poolFeeLibrary: TestPoolFeeLibrary
+}
+
+export function createPoolFeeLibraryFixture(): (wallets, provider) => Promise<PoolFeeLibraryFixture> {
+    return async ([owner], provider): Promise<PoolFeeLibraryFixture> => {
+        const factory = await ethers.getContractFactory("TestPoolFeeLibrary")
+        const poolFeeLibrary = (await factory.deploy()) as TestPoolFeeLibrary
+
+        return {
+            poolFeeLibrary,
+        }
+    }
+}

--- a/test/poolFeeLibrary/update.test.ts
+++ b/test/poolFeeLibrary/update.test.ts
@@ -1,0 +1,135 @@
+import { expect } from "chai"
+import { waffle } from "hardhat"
+import { TestPoolFeeLibrary } from "../../typechain"
+import { createPoolFeeLibraryFixture } from "./fixtures"
+import { getTimestamp, setNextTimestamp } from "../helper/time"
+import { BigNumber } from "ethers"
+
+describe("PoolFeeLibrary update", () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let library: TestPoolFeeLibrary
+
+    const Q96 = BigNumber.from(2).pow(96)
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPoolFeeLibraryFixture())
+        library = fixture.poolFeeLibrary
+    })
+
+    describe("various cases", () => {
+        ;[
+            {
+                title: "first time",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    referenceTimestamp: -1,
+                    currentHighX96: 0,
+                    currentLowX96: 0,
+                },
+                atrEmaBlocks: 1,
+                prevPriceX96: 1,
+                currentPriceX96: 2,
+                expected: {
+                    atrX96: 0,
+                    referenceTimestamp: 0,
+                    currentHighX96: 2,
+                    currentLowX96: 1,
+                },
+            },
+            {
+                title: "second time",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    referenceTimestamp: -1,
+                    currentHighX96: 2,
+                    currentLowX96: 1,
+                },
+                atrEmaBlocks: 1,
+                prevPriceX96: 2,
+                currentPriceX96: 4,
+                expected: {
+                    atrX96: Q96.div(2),
+                    referenceTimestamp: 0,
+                    currentHighX96: 4,
+                    currentLowX96: 2,
+                },
+            },
+            {
+                title: "same time high updated",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    referenceTimestamp: 0,
+                    currentHighX96: 3,
+                    currentLowX96: 2,
+                },
+                atrEmaBlocks: 1,
+                prevPriceX96: 1,
+                currentPriceX96: 4,
+                expected: {
+                    atrX96: 0,
+                    referenceTimestamp: 0,
+                    currentHighX96: 4,
+                    currentLowX96: 2,
+                },
+            },
+            {
+                title: "same time low updated",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    referenceTimestamp: 0,
+                    currentHighX96: 3,
+                    currentLowX96: 2,
+                },
+                atrEmaBlocks: 1,
+                prevPriceX96: 4,
+                currentPriceX96: 1,
+                expected: {
+                    atrX96: 0,
+                    referenceTimestamp: 0,
+                    currentHighX96: 3,
+                    currentLowX96: 1,
+                },
+            },
+            {
+                title: "future time",
+                poolFeeInfo: {
+                    atrX96: 0,
+                    referenceTimestamp: 1,
+                    currentHighX96: 3,
+                    currentLowX96: 2,
+                },
+                atrEmaBlocks: 1,
+                prevPriceX96: 1,
+                currentPriceX96: 4,
+                expected: {
+                    atrX96: 0,
+                    referenceTimestamp: 1,
+                    currentHighX96: 4,
+                    currentLowX96: 2,
+                },
+            },
+        ].forEach(test => {
+            it(test.title, async () => {
+                const currentTimestamp = await getTimestamp()
+                const nextTimeStamp = currentTimestamp + 1000
+                await setNextTimestamp(nextTimeStamp)
+                await library.update(
+                    {
+                        ...test.poolFeeInfo,
+                        referenceTimestamp: nextTimeStamp + test.poolFeeInfo.referenceTimestamp,
+                    },
+                    test.atrEmaBlocks,
+                    test.prevPriceX96,
+                    test.currentPriceX96,
+                )
+                const info = await library.poolFeeInfo()
+                expect(info.atrX96).to.eq(test.expected.atrX96)
+                expect(info.referenceTimestamp).to.eq(nextTimeStamp + test.expected.referenceTimestamp)
+                expect(info.currentHighX96).to.eq(test.expected.currentHighX96)
+                expect(info.currentLowX96).to.eq(test.expected.currentLowX96)
+            })
+        })
+    })
+})


### PR DESCRIPTION
changes

- add adaptive fee (PoolFeeLibrary)

todo

- write tests (coverage 100%)
- Examine if this feature is really good.
  - change adaptive fee algorithm (best algorithm in simulation script) 

## Adaptive fee

- calculate fee ratio using ATR
- large LP expected return (confirmed by numerical simulation)
- lower trade cost than fixed fee if sufficient LP exists

simulation: https://github.com/perpdex/perpdex-study/blob/master/work/amm_sim.ipynb