### PR TITLE
Feature/limit order

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "deps/perpdex-oracle-contract"]
 	path = deps/perpdex-oracle-contract
 	url = https://github.com/perpdex/perpdex-oracle-contract.git
+[submodule "deps/BokkyPooBahsRedBlackTreeLibrary"]
+	path = deps/BokkyPooBahsRedBlackTreeLibrary
+	url = https://github.com/perpdex/BokkyPooBahsRedBlackTreeLibrary.git

--- a/contracts/PerpdexExchange.sol
+++ b/contracts/PerpdexExchange.sol
@@ -255,7 +255,7 @@ contract PerpdexExchange is IPerpdexExchange, ReentrancyGuard, Ownable {
 
     function createLimitOrder(CreateLimitOrderParams calldata params)
         external
-        //    override
+        override
         nonReentrant
         checkDeadline(params.deadline)
         checkMarketAllowed(params.market)
@@ -282,7 +282,7 @@ contract PerpdexExchange is IPerpdexExchange, ReentrancyGuard, Ownable {
 
     function cancelLimitOrder(CancelLimitOrderParams calldata params)
         external
-        //    override
+        override
         nonReentrant
         checkDeadline(params.deadline)
         checkMarketAllowed(params.market)

--- a/contracts/PerpdexExchange.sol
+++ b/contracts/PerpdexExchange.sol
@@ -42,12 +42,12 @@ contract PerpdexExchange is IPerpdexExchange, ReentrancyGuard, Ownable {
     mapping(address => bool) public override isMarketAllowed;
 
     modifier checkDeadline(uint256 deadline) {
-        require(block.timestamp <= deadline, "PE_CD: too late");
+        _checkDeadline(deadline);
         _;
     }
 
     modifier checkMarketAllowed(address market) {
-        require(isMarketAllowed[market], "PE_CMA: market not allowed");
+        _checkMarketAllowed(market);
         _;
     }
 
@@ -486,5 +486,15 @@ contract PerpdexExchange is IPerpdexExchange, ReentrancyGuard, Ownable {
                     isSelf: params.trader == _msgSender()
                 })
             );
+    }
+
+    // to reduce contract size
+    function _checkDeadline(uint256 deadline) private view {
+        require(block.timestamp <= deadline, "PE_CD: too late");
+    }
+
+    // to reduce contract size
+    function _checkMarketAllowed(address market) private view {
+        require(isMarketAllowed[market], "PE_CMA: market not allowed");
     }
 }

--- a/contracts/PerpdexExchange.sol
+++ b/contracts/PerpdexExchange.sol
@@ -239,7 +239,7 @@ contract PerpdexExchange is IPerpdexExchange, ReentrancyGuard, Ownable {
         nonReentrant
         checkDeadline(params.deadline)
         checkMarketAllowed(params.market)
-        returns (uint256 orderId)
+        returns (uint40 orderId)
     {
         address trader = _msgSender();
         _settleLimitOrders(trader);

--- a/contracts/PerpdexMarket.sol
+++ b/contracts/PerpdexMarket.sol
@@ -221,11 +221,11 @@ contract PerpdexMarket is IPerpdexMarket, ReentrancyGuard, Ownable {
     }
 
     function orderBookLessThanAsk(uint40 key0, uint40 key1) private view returns (bool) {
-        return OrderBookLibrary.lessThan(orderBookInfoAsk, true, key0, key1);
+        return OrderBookLibrary.lessThan(orderBookInfoAsk, false, key0, key1);
     }
 
     function orderBookLessThanBid(uint40 key0, uint40 key1) private view returns (bool) {
-        return OrderBookLibrary.lessThan(orderBookInfoBid, false, key0, key1);
+        return OrderBookLibrary.lessThan(orderBookInfoBid, true, key0, key1);
     }
 
     function orderBookAggregateAsk(uint40 key) private returns (bool stop) {

--- a/contracts/PerpdexMarket.sol
+++ b/contracts/PerpdexMarket.sol
@@ -187,7 +187,10 @@ contract PerpdexMarket is IPerpdexMarket, ReentrancyGuard, Ownable {
         uint256 base,
         uint256 priceX96
     ) external override onlyExchange nonReentrant returns (uint256 orderId) {
+        uint256 markPrice = getMarkPriceX96();
+
         if (isBid) {
+            require(priceX96 <= markPrice, "PM_CLO: post only bid");
             orderId = OrderBookLibrary.createOrder(
                 orderBookInfoBid,
                 base,
@@ -196,6 +199,7 @@ contract PerpdexMarket is IPerpdexMarket, ReentrancyGuard, Ownable {
                 orderBookAggregateBid
             );
         } else {
+            require(priceX96 >= markPrice, "PM_CLO: post only ask");
             orderId = OrderBookLibrary.createOrder(
                 orderBookInfoAsk,
                 base,

--- a/contracts/PerpdexMarket.sol
+++ b/contracts/PerpdexMarket.sol
@@ -55,7 +55,7 @@ contract PerpdexMarket is IPerpdexMarket, ReentrancyGuard, Ownable {
         });
 
     modifier onlyExchange() {
-        require(exchange == msg.sender, "PM_OE: caller is not exchange");
+        _onlyExchange();
         _;
     }
 
@@ -423,5 +423,10 @@ contract PerpdexMarket is IPerpdexMarket, ReentrancyGuard, Ownable {
             sharePriceBound,
             poolInfo.baseBalancePerShareX96
         );
+    }
+
+    // to reduce contract size
+    function _onlyExchange() private view {
+        require(exchange == msg.sender, "PM_OE: caller is not exchange");
     }
 }

--- a/contracts/interfaces/IPerpdexExchange.sol
+++ b/contracts/interfaces/IPerpdexExchange.sol
@@ -161,6 +161,10 @@ interface IPerpdexExchange {
 
     function removeLiquidity(RemoveLiquidityParams calldata params) external returns (uint256 base, uint256 quote);
 
+    function createLimitOrder(CreateLimitOrderParams calldata params) external returns (uint40 orderId);
+
+    function cancelLimitOrder(CancelLimitOrderParams calldata params) external;
+
     function trade(TradeParams calldata params) external returns (uint256 oppositeAmount);
 
     // setters

--- a/contracts/interfaces/IPerpdexExchange.sol
+++ b/contracts/interfaces/IPerpdexExchange.sol
@@ -60,7 +60,6 @@ interface IPerpdexExchange {
     }
 
     struct CancelLimitOrderParams {
-        address trader;
         address market;
         bool isBid;
         uint40 orderId;

--- a/contracts/interfaces/IPerpdexExchange.sol
+++ b/contracts/interfaces/IPerpdexExchange.sol
@@ -51,6 +51,22 @@ interface IPerpdexExchange {
         bool isExactInput;
     }
 
+    struct CreateLimitOrderParams {
+        address market;
+        bool isBid;
+        uint256 base;
+        uint256 priceX96;
+        uint256 deadline;
+    }
+
+    struct CancelLimitOrderParams {
+        address trader;
+        address market;
+        bool isBid;
+        uint256 orderId;
+        uint256 deadline;
+    }
+
     event Deposited(address indexed trader, uint256 amount);
     event Withdrawn(address indexed trader, uint256 amount);
     event ProtocolFeeTransferred(address indexed trader, uint256 amount);
@@ -105,6 +121,22 @@ interface IPerpdexExchange {
         uint256 protocolFee,
         uint256 baseBalancePerShareX96,
         uint256 sharePriceAfterX96
+    );
+
+    event LimitOrderCreated(
+        address indexed trader,
+        address indexed market,
+        bool isBid,
+        uint256 base,
+        uint256 priceX96,
+        uint256 orderId
+    );
+
+    event LimitOrderCanceled(
+        address indexed trader,
+        address indexed market,
+        address indexed liquidator,
+        uint256 orderId
     );
 
     event MaxMarketsPerAccountChanged(uint8 value);

--- a/contracts/interfaces/IPerpdexExchange.sol
+++ b/contracts/interfaces/IPerpdexExchange.sol
@@ -63,7 +63,7 @@ interface IPerpdexExchange {
         address trader;
         address market;
         bool isBid;
-        uint256 orderId;
+        uint40 orderId;
         uint256 deadline;
     }
 

--- a/contracts/interfaces/IPerpdexMarket.sol
+++ b/contracts/interfaces/IPerpdexMarket.sol
@@ -16,6 +16,8 @@ interface IPerpdexMarket is IPerpdexMarketMinimum {
     event LiquidityAdded(uint256 base, uint256 quote, uint256 liquidity);
     event LiquidityRemoved(uint256 base, uint256 quote, uint256 liquidity);
     event Swapped(bool isBaseToQuote, bool isExactInput, uint256 amount, uint256 oppositeAmount);
+    event LimitOrderCreated(bool isBid, uint256 base, uint256 priceX96, uint256 orderId);
+    event LimitOrderCanceled(bool isBid, uint256 orderId);
 
     // getters
 

--- a/contracts/interfaces/IPerpdexMarketMinimum.sol
+++ b/contracts/interfaces/IPerpdexMarketMinimum.sol
@@ -20,6 +20,14 @@ interface IPerpdexMarketMinimum {
 
     function removeLiquidity(uint256 liquidity) external returns (uint256 baseShare, uint256 quoteBalance);
 
+    function createLimitOrder(
+        bool isBid,
+        uint256 baseShare,
+        uint256 priceX96
+    ) external returns (uint256 orderId);
+
+    function cancelLimitOrder(bool isBid, uint256 orderId) external;
+
     // getters
 
     function previewSwap(
@@ -50,4 +58,13 @@ interface IPerpdexMarketMinimum {
     function getCumDeleveragedPerLiquidityX96() external view returns (uint256, uint256);
 
     function baseBalancePerShareX96() external view returns (uint256);
+
+    function getLimitOrderInfo(bool isBid, uint256 orderId)
+        external
+        view
+        returns (
+            bool fullyExecuted,
+            int256 executedBase,
+            int256 executedQuote
+        );
 }

--- a/contracts/interfaces/IPerpdexMarketMinimum.sol
+++ b/contracts/interfaces/IPerpdexMarketMinimum.sol
@@ -3,12 +3,19 @@ pragma solidity >=0.7.6;
 pragma abicoder v2;
 
 interface IPerpdexMarketMinimum {
+    struct SwapResponse {
+        uint256 oppositeAmount;
+        uint256 basePartial;
+        uint256 quotePartial;
+        uint40 partialKey;
+    }
+
     function swap(
         bool isBaseToQuote,
         bool isExactInput,
         uint256 amount,
         bool isLiquidation
-    ) external returns (uint256);
+    ) external returns (SwapResponse memory response);
 
     function addLiquidity(uint256 baseShare, uint256 quoteBalance)
         external
@@ -24,9 +31,9 @@ interface IPerpdexMarketMinimum {
         bool isBid,
         uint256 baseShare,
         uint256 priceX96
-    ) external returns (uint256 orderId);
+    ) external returns (uint40 orderId);
 
-    function cancelLimitOrder(bool isBid, uint256 orderId) external;
+    function cancelLimitOrder(bool isBid, uint40 orderId) external;
 
     // getters
 
@@ -59,12 +66,12 @@ interface IPerpdexMarketMinimum {
 
     function baseBalancePerShareX96() external view returns (uint256);
 
-    function getLimitOrderInfo(bool isBid, uint256 orderId)
+    function getLimitOrderExecution(bool isBid, uint40 orderId)
         external
         view
         returns (
-            bool fullyExecuted,
-            int256 executedBase,
-            int256 executedQuote
+            uint256 executionId,
+            uint256 executedBase,
+            uint256 executedQuote
         );
 }

--- a/contracts/lib/AccountLibrary.sol
+++ b/contracts/lib/AccountLibrary.sol
@@ -27,7 +27,8 @@ library AccountLibrary {
         bool enabled =
             accountInfo.takerInfos[market].baseBalanceShare != 0 ||
                 accountInfo.makerInfos[market].liquidity != 0 ||
-                accountInfo.limitOrderInfos[market].length > 0;
+                accountInfo.limitOrderInfos[market].ask.root != 0 ||
+                accountInfo.limitOrderInfos[market].bid.root != 0;
         address[] storage markets = accountInfo.markets;
         uint256 length = markets.length;
 

--- a/contracts/lib/AccountLibrary.sol
+++ b/contracts/lib/AccountLibrary.sol
@@ -9,6 +9,7 @@ import { PRBMath } from "prb-math/contracts/PRBMath.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import { IPerpdexMarketMinimum } from "../interfaces/IPerpdexMarketMinimum.sol";
 import { PerpdexStructs } from "./PerpdexStructs.sol";
+import { AccountPreviewLibrary } from "./AccountPreviewLibrary.sol";
 
 // https://help.ftx.com/hc/en-us/articles/360024780511-Complete-Futures-Specs
 library AccountLibrary {
@@ -24,7 +25,9 @@ library AccountLibrary {
         uint8 maxMarketsPerAccount
     ) internal {
         bool enabled =
-            accountInfo.takerInfos[market].baseBalanceShare != 0 || accountInfo.makerInfos[market].liquidity != 0;
+            accountInfo.takerInfos[market].baseBalanceShare != 0 ||
+                accountInfo.makerInfos[market].liquidity != 0 ||
+                accountInfo.limitOrderInfos[market].length > 0;
         address[] storage markets = accountInfo.markets;
         uint256 length = markets.length;
 
@@ -44,16 +47,24 @@ library AccountLibrary {
         markets.push(market);
     }
 
-    function getTotalAccountValue(PerpdexStructs.AccountInfo storage accountInfo) internal view returns (int256) {
+    function getTotalAccountValue(PerpdexStructs.AccountInfo storage accountInfo)
+        internal
+        view
+        returns (int256 accountValue, int256 collateralBalance)
+    {
         address[] storage markets = accountInfo.markets;
-        int256 accountValue = accountInfo.vaultInfo.collateralBalance;
+        collateralBalance = accountInfo.vaultInfo.collateralBalance;
         uint256 length = markets.length;
         for (uint256 i = 0; i < length; ++i) {
             address market = markets[i];
 
             PerpdexStructs.MakerInfo storage makerInfo = accountInfo.makerInfos[market];
-            int256 baseShare = accountInfo.takerInfos[market].baseBalanceShare;
-            int256 quoteBalance = accountInfo.takerInfos[market].quoteBalance;
+
+            (PerpdexStructs.TakerInfo memory takerInfo, int256 realizedPnl) =
+                AccountPreviewLibrary.previewSettleLimitOrders(accountInfo, market);
+            int256 baseShare = takerInfo.baseBalanceShare;
+            int256 quoteBalance = takerInfo.quoteBalance;
+            collateralBalance = collateralBalance.add(realizedPnl);
 
             if (makerInfo.liquidity != 0) {
                 (uint256 poolBaseShare, uint256 poolQuoteBalance) =
@@ -74,7 +85,7 @@ library AccountLibrary {
             }
             accountValue = accountValue.add(quoteBalance);
         }
-        return accountValue;
+        accountValue = accountValue.add(collateralBalance);
     }
 
     function getPositionShare(PerpdexStructs.AccountInfo storage accountInfo, address market)
@@ -83,7 +94,10 @@ library AccountLibrary {
         returns (int256 baseShare)
     {
         PerpdexStructs.MakerInfo storage makerInfo = accountInfo.makerInfos[market];
-        baseShare = accountInfo.takerInfos[market].baseBalanceShare;
+        (PerpdexStructs.TakerInfo memory takerInfo, ) =
+            AccountPreviewLibrary.previewSettleLimitOrders(accountInfo, market);
+        baseShare = takerInfo.baseBalanceShare;
+
         if (makerInfo.liquidity != 0) {
             (uint256 poolBaseShare, ) = IPerpdexMarketMinimum(market).getLiquidityValue(makerInfo.liquidity);
             (int256 deleveragedBaseShare, ) =
@@ -163,7 +177,7 @@ library AccountLibrary {
         view
         returns (bool)
     {
-        int256 accountValue = getTotalAccountValue(accountInfo);
+        (int256 accountValue, ) = getTotalAccountValue(accountInfo);
         uint256 totalPositionNotional = getTotalPositionNotional(accountInfo);
         return accountValue >= totalPositionNotional.mulRatio(mmRatio).toInt256();
     }
@@ -173,11 +187,10 @@ library AccountLibrary {
         view
         returns (bool)
     {
-        int256 accountValue = getTotalAccountValue(accountInfo);
+        (int256 accountValue, int256 collateralBalance) = getTotalAccountValue(accountInfo);
         uint256 totalOpenPositionNotional = getTotalOpenPositionNotional(accountInfo);
         return
-            accountValue.min(accountInfo.vaultInfo.collateralBalance) >=
-            totalOpenPositionNotional.mulRatio(imRatio).toInt256() ||
+            accountValue.min(collateralBalance) >= totalOpenPositionNotional.mulRatio(imRatio).toInt256() ||
             isLiquidationFree(accountInfo);
     }
 
@@ -189,8 +202,11 @@ library AccountLibrary {
             address market = markets[i];
 
             PerpdexStructs.MakerInfo storage makerInfo = accountInfo.makerInfos[market];
-            int256 baseShare = accountInfo.takerInfos[market].baseBalanceShare;
-            quoteBalance = quoteBalance.add(accountInfo.takerInfos[market].quoteBalance);
+            (PerpdexStructs.TakerInfo memory takerInfo, int256 realizedPnl) =
+                AccountPreviewLibrary.previewSettleLimitOrders(accountInfo, market);
+
+            int256 baseShare = takerInfo.baseBalanceShare;
+            quoteBalance = quoteBalance.add(takerInfo.quoteBalance).add(realizedPnl);
 
             if (makerInfo.liquidity != 0) {
                 (int256 deleveragedBaseShare, int256 deleveragedQuoteBalance) =

--- a/contracts/lib/AccountLibrary.sol
+++ b/contracts/lib/AccountLibrary.sol
@@ -23,7 +23,7 @@ library AccountLibrary {
         PerpdexStructs.AccountInfo storage accountInfo,
         address market,
         uint8 maxMarketsPerAccount
-    ) internal {
+    ) public {
         bool enabled =
             accountInfo.takerInfos[market].baseBalanceShare != 0 ||
                 accountInfo.makerInfos[market].liquidity != 0 ||
@@ -49,7 +49,7 @@ library AccountLibrary {
     }
 
     function getTotalAccountValue(PerpdexStructs.AccountInfo storage accountInfo)
-        internal
+        public
         view
         returns (int256 accountValue, int256 collateralBalance)
     {
@@ -90,7 +90,7 @@ library AccountLibrary {
     }
 
     function getPositionShare(PerpdexStructs.AccountInfo storage accountInfo, address market)
-        internal
+        public
         view
         returns (int256 baseShare)
     {
@@ -112,7 +112,7 @@ library AccountLibrary {
     }
 
     function getPositionNotional(PerpdexStructs.AccountInfo storage accountInfo, address market)
-        internal
+        public
         view
         returns (int256)
     {
@@ -122,7 +122,7 @@ library AccountLibrary {
         return positionShare.mulDiv(sharePriceX96.toInt256(), FixedPoint96.Q96);
     }
 
-    function getTotalPositionNotional(PerpdexStructs.AccountInfo storage accountInfo) internal view returns (uint256) {
+    function getTotalPositionNotional(PerpdexStructs.AccountInfo storage accountInfo) public view returns (uint256) {
         address[] storage markets = accountInfo.markets;
         uint256 totalPositionNotional;
         uint256 length = markets.length;
@@ -134,7 +134,7 @@ library AccountLibrary {
     }
 
     function getOpenPositionShare(PerpdexStructs.AccountInfo storage accountInfo, address market)
-        internal
+        public
         view
         returns (uint256 result)
     {
@@ -147,7 +147,7 @@ library AccountLibrary {
     }
 
     function getOpenPositionNotional(PerpdexStructs.AccountInfo storage accountInfo, address market)
-        internal
+        public
         view
         returns (uint256)
     {
@@ -158,7 +158,7 @@ library AccountLibrary {
     }
 
     function getTotalOpenPositionNotional(PerpdexStructs.AccountInfo storage accountInfo)
-        internal
+        public
         view
         returns (uint256)
     {
@@ -174,7 +174,7 @@ library AccountLibrary {
 
     // always true when hasEnoughMaintenanceMargin is true
     function hasEnoughMaintenanceMargin(PerpdexStructs.AccountInfo storage accountInfo, uint24 mmRatio)
-        internal
+        public
         view
         returns (bool)
     {
@@ -184,7 +184,7 @@ library AccountLibrary {
     }
 
     function hasEnoughInitialMargin(PerpdexStructs.AccountInfo storage accountInfo, uint24 imRatio)
-        internal
+        public
         view
         returns (bool)
     {
@@ -195,7 +195,7 @@ library AccountLibrary {
             isLiquidationFree(accountInfo);
     }
 
-    function isLiquidationFree(PerpdexStructs.AccountInfo storage accountInfo) internal view returns (bool) {
+    function isLiquidationFree(PerpdexStructs.AccountInfo storage accountInfo) public view returns (bool) {
         address[] storage markets = accountInfo.markets;
         int256 quoteBalance = accountInfo.vaultInfo.collateralBalance;
         uint256 length = markets.length;

--- a/contracts/lib/AccountPreviewLibrary.sol
+++ b/contracts/lib/AccountPreviewLibrary.sol
@@ -66,14 +66,11 @@ library AccountPreviewLibrary {
         takerInfo = accountInfo.takerInfos[market];
 
         PerpdexStructs.LimitOrderInfo[] storage limitOrderInfos = accountInfo.limitOrderInfos[market];
-        uint256 length = limitOrderInfos.length;
         int256 firstSettlingBase;
         int256 firstSettlingQuote;
         int256 secondSettlingBase;
         int256 secondSettlingQuote;
-        for (int256 i2 = length.toInt256() - 1; i2 >= 0; --i2) {
-            uint256 i = i2.toUint256();
-
+        for (uint256 i = limitOrderInfos.length - 1; i-- > 0; ) {
             (, int256 executedBase, int256 executedQuote) =
                 IPerpdexMarketMinimum(market).getLimitOrderInfo(limitOrderInfos[i].isBid, limitOrderInfos[i].orderId);
 

--- a/contracts/lib/AccountPreviewLibrary.sol
+++ b/contracts/lib/AccountPreviewLibrary.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import { SignedSafeMath } from "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
+import { PRBMath } from "prb-math/contracts/PRBMath.sol";
+import { FixedPoint96 } from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
+import { IPerpdexMarketMinimum } from "../interfaces/IPerpdexMarketMinimum.sol";
+import { PerpMath } from "./PerpMath.sol";
+import { PerpdexStructs } from "./PerpdexStructs.sol";
+
+// This is a technical library to avoid circular references between libraries
+library AccountPreviewLibrary {
+    using PerpMath for int256;
+    using PerpMath for uint256;
+    using SafeCast for int256;
+    using SafeCast for uint256;
+    using SafeMath for uint256;
+    using SignedSafeMath for int256;
+
+    function previewAddToTakerBalance(
+        PerpdexStructs.TakerInfo memory takerInfo,
+        int256 baseShare,
+        int256 quoteBalance,
+        int256 quoteFee
+    ) internal view returns (PerpdexStructs.TakerInfo memory resultTakerInfo, int256 realizedPnl) {
+        if (baseShare != 0 || quoteBalance != 0) {
+            require(baseShare.sign() * quoteBalance.sign() == -1, "TL_ATTB: invalid input");
+
+            if (takerInfo.baseBalanceShare.sign() * baseShare.sign() == -1) {
+                uint256 baseAbs = baseShare.abs();
+                uint256 takerBaseAbs = takerInfo.baseBalanceShare.abs();
+
+                if (baseAbs <= takerBaseAbs) {
+                    int256 reducedOpenNotional = takerInfo.quoteBalance.mulDiv(baseAbs.toInt256(), takerBaseAbs);
+                    realizedPnl = quoteBalance.add(reducedOpenNotional);
+                } else {
+                    int256 closedPositionNotional = quoteBalance.mulDiv(takerBaseAbs.toInt256(), baseAbs);
+                    realizedPnl = takerInfo.quoteBalance.add(closedPositionNotional);
+                }
+            }
+        }
+        realizedPnl = realizedPnl.add(quoteFee);
+
+        int256 newBaseBalanceShare = takerInfo.baseBalanceShare.add(baseShare);
+        int256 newQuoteBalance = takerInfo.quoteBalance.add(quoteBalance).add(quoteFee).sub(realizedPnl);
+        require(
+            (newBaseBalanceShare == 0 && newQuoteBalance == 0) ||
+                newBaseBalanceShare.sign() * newQuoteBalance.sign() == -1,
+            "TL_ATTB: never occur"
+        );
+
+        resultTakerInfo.baseBalanceShare = newBaseBalanceShare;
+        resultTakerInfo.quoteBalance = newQuoteBalance;
+    }
+
+    // we use batch execution rules
+    // see https://medium.com/perpdex/order-dependency-of-trade-execution-ce6d2907eb4f
+    function previewSettleLimitOrders(PerpdexStructs.AccountInfo storage accountInfo, address market)
+        internal
+        view
+        returns (PerpdexStructs.TakerInfo memory takerInfo, int256 realizedPnl)
+    {
+        takerInfo = accountInfo.takerInfos[market];
+
+        PerpdexStructs.LimitOrderInfo[] storage limitOrderInfos = accountInfo.limitOrderInfos[market];
+        uint256 length = limitOrderInfos.length;
+        int256 firstSettlingBase;
+        int256 firstSettlingQuote;
+        int256 secondSettlingBase;
+        int256 secondSettlingQuote;
+        for (int256 i2 = length.toInt256() - 1; i2 >= 0; --i2) {
+            uint256 i = i2.toUint256();
+
+            (, int256 executedBase, int256 executedQuote) =
+                IPerpdexMarketMinimum(market).getLimitOrderInfo(limitOrderInfos[i].isBid, limitOrderInfos[i].orderId);
+
+            int256 settlingBase = executedBase - limitOrderInfos[i].settledBaseShare;
+            int256 settlingQuote = executedQuote - limitOrderInfos[i].settledQuote;
+
+            if ((settlingBase >= 0) == (takerInfo.baseBalanceShare >= 0)) {
+                firstSettlingBase += settlingBase;
+                firstSettlingQuote += settlingQuote;
+            } else {
+                secondSettlingBase += settlingBase;
+                secondSettlingQuote += settlingQuote;
+            }
+        }
+
+        if (firstSettlingBase != 0) {
+            (takerInfo, realizedPnl) = previewAddToTakerBalance(takerInfo, firstSettlingBase, firstSettlingQuote, 0);
+        }
+        int256 secondRealizedPnl;
+        if (secondSettlingBase != 0) {
+            (takerInfo, secondRealizedPnl) = previewAddToTakerBalance(
+                takerInfo,
+                secondSettlingBase,
+                secondSettlingQuote,
+                0
+            );
+            realizedPnl += secondRealizedPnl;
+        }
+    }
+}

--- a/contracts/lib/AccountPreviewLibrary.sol
+++ b/contracts/lib/AccountPreviewLibrary.sol
@@ -70,7 +70,9 @@ library AccountPreviewLibrary {
         int256 firstSettlingQuote;
         int256 secondSettlingBase;
         int256 secondSettlingQuote;
-        for (uint256 i = limitOrderInfos.length - 1; i-- > 0; ) {
+        uint256 i = limitOrderInfos.length;
+        while (i > 0) {
+            --i;
             (, int256 executedBase, int256 executedQuote) =
                 IPerpdexMarketMinimum(market).getLimitOrderInfo(limitOrderInfos[i].isBid, limitOrderInfos[i].orderId);
 

--- a/contracts/lib/MakerLibrary.sol
+++ b/contracts/lib/MakerLibrary.sol
@@ -106,7 +106,7 @@ library MakerLibrary {
         uint256 addedToken,
         uint256 cumBefore,
         uint256 cumAfter
-    ) internal pure returns (uint256) {
+    ) private pure returns (uint256) {
         uint256 liquidityAfter = liquidityBefore.add(addedLiquidity);
         cumAfter = cumAfter.add(PRBMath.mulDiv(addedToken, FixedPoint96.Q96, addedLiquidity));
 

--- a/contracts/lib/MakerOrderBookLibrary.sol
+++ b/contracts/lib/MakerOrderBookLibrary.sol
@@ -87,7 +87,9 @@ library MakerOrderBookLibrary {
 
     function settleLimitOrdersAll(PerpdexStructs.AccountInfo storage accountInfo, uint8 maxMarketsPerAccount) internal {
         address[] storage markets = accountInfo.markets;
-        for (uint256 i = markets.length; i-- > 0; ) {
+        uint256 i = markets.length;
+        while (i > 0) {
+            --i;
             settleLimitOrders(accountInfo, markets[i], maxMarketsPerAccount);
         }
     }
@@ -104,7 +106,9 @@ library MakerOrderBookLibrary {
         int256 firstSettlingQuote;
         int256 secondSettlingBase;
         int256 secondSettlingQuote;
-        for (uint256 i = limitOrderInfos.length; i-- > 0; ) {
+        uint256 i = limitOrderInfos.length;
+        while (i > 0) {
+            --i;
             (bool fullyExecuted, int256 executedBase, int256 executedQuote) =
                 IPerpdexMarketMinimum(market).getLimitOrderInfo(limitOrderInfos[i].isBid, limitOrderInfos[i].orderId);
 

--- a/contracts/lib/MakerOrderBookLibrary.sol
+++ b/contracts/lib/MakerOrderBookLibrary.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import { PRBMath } from "prb-math/contracts/PRBMath.sol";
+import { FixedPoint96 } from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import { SignedSafeMath } from "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
+import { PerpMath } from "./PerpMath.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { IPerpdexMarketMinimum } from "../interfaces/IPerpdexMarketMinimum.sol";
+import { PerpdexStructs } from "./PerpdexStructs.sol";
+import { AccountLibrary } from "./AccountLibrary.sol";
+import { TakerLibrary } from "./TakerLibrary.sol";
+
+library MakerOrderBookLibrary {
+    using PerpMath for int256;
+    using SafeCast for int256;
+    using SafeCast for uint256;
+    using SafeMath for uint256;
+    using SignedSafeMath for int256;
+
+    struct CreateLimitOrderParams {
+        address market;
+        uint256 base;
+        uint256 priceX96;
+        bool isBid;
+        uint24 imRatio;
+        uint8 maxMarketsPerAccount;
+    }
+
+    struct CancelLimitOrderParams {
+        address market;
+        uint256 orderId;
+        bool isBid;
+        uint24 mmRatio;
+        bool isSelf;
+        uint8 maxMarketsPerAccount;
+    }
+
+    function createLimitOrder(PerpdexStructs.AccountInfo storage accountInfo, CreateLimitOrderParams memory params)
+        internal
+        returns (uint256 orderId)
+    {
+        orderId = IPerpdexMarketMinimum(params.market).createLimitOrder(params.isBid, params.base, params.priceX96);
+
+        PerpdexStructs.LimitOrderInfo[] storage limitOrderInfos = accountInfo.limitOrderInfos[params.market];
+        limitOrderInfos.push(
+            PerpdexStructs.LimitOrderInfo({
+                orderId: orderId,
+                isBid: params.isBid,
+                settledBaseShare: 0,
+                settledQuote: 0
+            })
+        );
+
+        AccountLibrary.updateMarkets(accountInfo, params.market, params.maxMarketsPerAccount);
+
+        require(AccountLibrary.hasEnoughInitialMargin(accountInfo, params.imRatio), "MOBL_CLO: not enough im");
+    }
+
+    function cancelLimitOrder(PerpdexStructs.AccountInfo storage accountInfo, CancelLimitOrderParams memory params)
+        internal
+        returns (bool isLiquidation)
+    {
+        isLiquidation = !AccountLibrary.hasEnoughMaintenanceMargin(accountInfo, params.mmRatio);
+
+        if (!params.isSelf) {
+            require(isLiquidation, "MOBL_CLO: enough mm");
+        }
+
+        IPerpdexMarketMinimum(params.market).cancelLimitOrder(params.isBid, params.orderId);
+
+        PerpdexStructs.LimitOrderInfo[] storage limitOrderInfos = accountInfo.limitOrderInfos[params.market];
+        uint256 length = limitOrderInfos.length;
+        for (uint256 i = 0; i < length; ++i) {
+            if (limitOrderInfos[i].orderId == params.orderId) {
+                limitOrderInfos[i] = limitOrderInfos[length - 1];
+                limitOrderInfos.pop();
+                return isLiquidation;
+            }
+        }
+        require(false, "MOBL_CLO: order not exist");
+
+        AccountLibrary.updateMarkets(accountInfo, params.market, params.maxMarketsPerAccount);
+    }
+
+    function settleLimitOrders(
+        PerpdexStructs.AccountInfo storage accountInfo,
+        address market,
+        uint8 maxMarketsPerAccount
+    ) internal {
+        bool currentIsLong = accountInfo.takerInfos[market].baseBalanceShare >= 0;
+
+        PerpdexStructs.LimitOrderInfo[] storage limitOrderInfos = accountInfo.limitOrderInfos[market];
+        uint256 length = limitOrderInfos.length;
+        int256 firstSettlingBase;
+        int256 firstSettlingQuote;
+        int256 secondSettlingBase;
+        int256 secondSettlingQuote;
+        for (int256 i2 = length.toInt256() - 1; i2 >= 0; --i2) {
+            uint256 i = i2.toUint256();
+
+            (bool fullyExecuted, int256 executedBase, int256 executedQuote) =
+                IPerpdexMarketMinimum(market).getLimitOrderInfo(limitOrderInfos[i].isBid, limitOrderInfos[i].orderId);
+
+            int256 settlingBase = executedBase - limitOrderInfos[i].settledBaseShare;
+            int256 settlingQuote = executedQuote - limitOrderInfos[i].settledQuote;
+
+            if ((settlingBase >= 0) == currentIsLong) {
+                firstSettlingBase += settlingBase;
+                firstSettlingQuote += settlingQuote;
+            } else {
+                secondSettlingBase += settlingBase;
+                secondSettlingQuote += settlingQuote;
+            }
+
+            if (fullyExecuted) {
+                limitOrderInfos[i] = limitOrderInfos[length - 1];
+                limitOrderInfos.pop();
+            } else {
+                limitOrderInfos[i].settledBaseShare = executedBase;
+                limitOrderInfos[i].settledBaseShare = executedQuote;
+            }
+        }
+
+        if (firstSettlingBase != 0) {
+            TakerLibrary.addToTakerBalance(
+                accountInfo,
+                market,
+                firstSettlingBase,
+                firstSettlingQuote,
+                0,
+                maxMarketsPerAccount
+            );
+        }
+        if (secondSettlingBase != 0) {
+            TakerLibrary.addToTakerBalance(
+                accountInfo,
+                market,
+                secondSettlingBase,
+                secondSettlingQuote,
+                0,
+                maxMarketsPerAccount
+            );
+        }
+    }
+}

--- a/contracts/lib/MakerOrderBookLibrary.sol
+++ b/contracts/lib/MakerOrderBookLibrary.sol
@@ -44,7 +44,7 @@ library MakerOrderBookLibrary {
     }
 
     function createLimitOrder(PerpdexStructs.AccountInfo storage accountInfo, CreateLimitOrderParams memory params)
-        internal
+        public
         returns (uint40 orderId)
     {
         orderId = IPerpdexMarketMinimum(params.market).createLimitOrder(params.isBid, params.base, params.priceX96);
@@ -63,7 +63,7 @@ library MakerOrderBookLibrary {
     }
 
     function cancelLimitOrder(PerpdexStructs.AccountInfo storage accountInfo, CancelLimitOrderParams memory params)
-        internal
+        public
         returns (bool isLiquidation)
     {
         isLiquidation = !AccountLibrary.hasEnoughMaintenanceMargin(accountInfo, params.mmRatio);
@@ -131,7 +131,7 @@ library MakerOrderBookLibrary {
 
     function subtreeRemoved(uint40 key, uint256 slot) private pure {}
 
-    function settleLimitOrdersAll(PerpdexStructs.AccountInfo storage accountInfo, uint8 maxMarketsPerAccount) internal {
+    function settleLimitOrdersAll(PerpdexStructs.AccountInfo storage accountInfo, uint8 maxMarketsPerAccount) public {
         address[] storage markets = accountInfo.markets;
         uint256 i = markets.length;
         while (i > 0) {
@@ -144,7 +144,7 @@ library MakerOrderBookLibrary {
         PerpdexStructs.AccountInfo storage accountInfo,
         address market,
         uint8 maxMarketsPerAccount
-    ) internal {
+    ) private {
         PerpdexStructs.LimitOrderInfo storage limitOrderInfo = accountInfo.limitOrderInfos[market];
         (
             AccountPreviewLibrary.Execution[] memory executions,

--- a/contracts/lib/MarketStructs.sol
+++ b/contracts/lib/MarketStructs.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.7.6;
 
+import {
+    BokkyPooBahsRedBlackTreeLibrary as RBTreeLibrary
+} from "../../deps/BokkyPooBahsRedBlackTreeLibrary/contracts/BokkyPooBahsRedBlackTreeLibrary.sol";
+
 library MarketStructs {
     struct FundingInfo {
         uint256 prevIndexPriceBase;
@@ -29,5 +33,17 @@ library MarketStructs {
         uint24 emaNormalOrderRatio;
         uint24 emaLiquidationRatio;
         uint32 emaSec;
+    }
+
+    struct OrderInfo {
+        uint256 base;
+        uint256 baseSum;
+        uint256 quoteSum;
+    }
+
+    struct OrderBookSideInfo {
+        RBTreeLibrary.Tree tree;
+        uint40 seqKey;
+        mapping(uint40 => OrderInfo) orderInfos;
     }
 }

--- a/contracts/lib/MarketStructs.sol
+++ b/contracts/lib/MarketStructs.sol
@@ -39,6 +39,8 @@ library MarketStructs {
         uint256 base;
         uint256 baseSum;
         uint256 quoteSum;
+        uint256 baseExecuted;
+        uint256 quoteExecuted;
     }
 
     struct OrderBookSideInfo {

--- a/contracts/lib/MarketStructs.sol
+++ b/contracts/lib/MarketStructs.sol
@@ -53,6 +53,8 @@ library MarketStructs {
     }
 
     struct OrderBookInfo {
+        OrderBookSideInfo ask;
+        OrderBookSideInfo bid;
         uint48 seqExecutionId;
         mapping(uint48 => ExecutionInfo) executionInfos;
     }

--- a/contracts/lib/MarketStructs.sol
+++ b/contracts/lib/MarketStructs.sol
@@ -39,13 +39,21 @@ library MarketStructs {
         uint256 base;
         uint256 baseSum;
         uint256 quoteSum;
-        uint256 baseExecuted;
-        uint256 quoteExecuted;
+        uint48 executionId;
     }
 
     struct OrderBookSideInfo {
         RBTreeLibrary.Tree tree;
-        uint40 seqKey;
         mapping(uint40 => OrderInfo) orderInfos;
+        uint40 seqKey;
+    }
+
+    struct ExecutionInfo {
+        uint256 baseBalancePerShareX96;
+    }
+
+    struct OrderBookInfo {
+        uint48 seqExecutionId;
+        mapping(uint48 => ExecutionInfo) executionInfos;
     }
 }

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -46,7 +46,7 @@ library OrderBookLibrary {
         bool isBid,
         uint256 base,
         uint256 priceX96
-    ) internal returns (uint40) {
+    ) public returns (uint40) {
         require(base > 0, "OBL_CO: base is zero");
         require(priceX96 > 0, "OBL_CO: price is zero");
         MarketStructs.OrderBookSideInfo storage info = isBid ? orderBookInfo.bid : orderBookInfo.ask;
@@ -67,7 +67,7 @@ library OrderBookLibrary {
         MarketStructs.OrderBookInfo storage orderBookInfo,
         bool isBid,
         uint40 key
-    ) internal {
+    ) public {
         MarketStructs.OrderBookSideInfo storage info = isBid ? orderBookInfo.bid : orderBookInfo.ask;
         require(isFullyExecuted(info, key) == 0, "already fully executed");
         uint256 slot = getSlot(orderBookInfo);
@@ -84,7 +84,7 @@ library OrderBookLibrary {
         bool isBid,
         uint40 key
     )
-        internal
+        public
         view
         returns (
             uint48 executionId,
@@ -363,7 +363,7 @@ library OrderBookLibrary {
         bool isExactInput,
         uint256 sharePriceBoundX96,
         uint256 baseBalancePerShareX96
-    ) internal view returns (uint256 amount) {
+    ) public view returns (uint256 amount) {
         uint256 priceBoundX96 = PRBMath.mulDiv(sharePriceBoundX96, FixedPoint96.Q96, baseBalancePerShareX96);
         bool isBid = isBaseToQuote;
         bool isBase = isBaseToQuote == isExactInput;

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -42,34 +42,46 @@ library OrderBookLibrary {
     }
 
     function createOrder(
-        MarketStructs.OrderBookSideInfo storage info,
+        MarketStructs.OrderBookInfo storage orderBookInfo,
         bool isBid,
         uint256 base,
-        uint256 priceX96,
-        function(uint40) returns (bool) aggregateArg
+        uint256 priceX96
     ) internal returns (uint40) {
         require(base > 0, "OBL_CO: base is zero");
         require(priceX96 > 0, "OBL_CO: price is zero");
+        MarketStructs.OrderBookSideInfo storage info = isBid ? orderBookInfo.bid : orderBookInfo.ask;
         uint40 key = info.seqKey + 1;
         info.seqKey = key;
         info.orderInfos[key].base = base; // before insert for aggregation
-        info.tree.insert(key, makeUserData(priceX96), isBid ? lessThanBid : lessThanAsk, aggregateArg);
+        uint128 userData = makeUserData(priceX96);
+        uint256 slot = getSlot(orderBookInfo);
+        if (isBid) {
+            info.tree.insert(key, userData, lessThanBid, aggregateBid, slot);
+        } else {
+            info.tree.insert(key, userData, lessThanAsk, aggregateAsk, slot);
+        }
         return key;
     }
 
     function cancelOrder(
-        MarketStructs.OrderBookSideInfo storage info,
-        uint40 key,
-        function(uint40) returns (bool) aggregateArg
+        MarketStructs.OrderBookInfo storage orderBookInfo,
+        bool isBid,
+        uint40 key
     ) internal {
+        MarketStructs.OrderBookSideInfo storage info = isBid ? orderBookInfo.bid : orderBookInfo.ask;
         require(isFullyExecuted(info, key) == 0, "already fully executed");
-        info.tree.remove(key, aggregateArg);
+        uint256 slot = getSlot(orderBookInfo);
+        if (isBid) {
+            info.tree.remove(key, aggregateBid, slot);
+        } else {
+            info.tree.remove(key, aggregateAsk, slot);
+        }
         delete info.orderInfos[key];
     }
 
     function getOrderExecution(
-        MarketStructs.OrderBookSideInfo storage info,
         MarketStructs.OrderBookInfo storage orderBookInfo,
+        bool isBid,
         uint40 key
     )
         internal
@@ -80,6 +92,7 @@ library OrderBookLibrary {
             uint256 executedQuote
         )
     {
+        MarketStructs.OrderBookSideInfo storage info = isBid ? orderBookInfo.bid : orderBookInfo.ask;
         executionId = isFullyExecuted(info, key);
         if (executionId == 0) return (0, 0, 0);
 
@@ -111,35 +124,40 @@ library OrderBookLibrary {
         return userData;
     }
 
-    function lessThanAsk(
+    function lessThan(
         RBTreeLibrary.Tree storage tree,
+        bool isBid,
         uint40 key0,
         uint40 key1
-    ) internal view returns (bool) {
+    ) private view returns (bool) {
         uint128 price0 = userDataToPriceX96(tree.nodes[key0].userData);
         uint128 price1 = userDataToPriceX96(tree.nodes[key1].userData);
         if (price0 == price1) {
             return key0 < key1; // time priority
         }
         // price priority
-        return price0 < price1;
+        return isBid ? price0 > price1 : price0 < price1;
+    }
+
+    function lessThanAsk(
+        uint40 key0,
+        uint40 key1,
+        uint256 slot
+    ) private view returns (bool) {
+        MarketStructs.OrderBookInfo storage info = getOrderBookInfoFromSlot(slot);
+        return lessThan(info.ask.tree, false, key0, key1);
     }
 
     function lessThanBid(
-        RBTreeLibrary.Tree storage tree,
         uint40 key0,
-        uint40 key1
-    ) internal view returns (bool) {
-        uint128 price0 = userDataToPriceX96(tree.nodes[key0].userData);
-        uint128 price1 = userDataToPriceX96(tree.nodes[key1].userData);
-        if (price0 == price1) {
-            return key0 < key1; // time priority
-        }
-        // price priority
-        return price0 > price1;
+        uint40 key1,
+        uint256 slot
+    ) private view returns (bool) {
+        MarketStructs.OrderBookInfo storage info = getOrderBookInfoFromSlot(slot);
+        return lessThan(info.bid.tree, true, key0, key1);
     }
 
-    function aggregate(MarketStructs.OrderBookSideInfo storage info, uint40 key) internal returns (bool stop) {
+    function aggregate(MarketStructs.OrderBookSideInfo storage info, uint40 key) private returns (bool stop) {
         uint256 prevBaseSum = info.orderInfos[key].baseSum;
         uint256 prevQuoteSum = info.orderInfos[key].quoteSum;
         uint40 left = info.tree.nodes[key].left;
@@ -155,12 +173,32 @@ library OrderBookLibrary {
         }
     }
 
+    function aggregateAsk(uint40 key, uint256 slot) private returns (bool stop) {
+        MarketStructs.OrderBookInfo storage info = getOrderBookInfoFromSlot(slot);
+        return aggregate(info.ask, key);
+    }
+
+    function aggregateBid(uint40 key, uint256 slot) private returns (bool stop) {
+        MarketStructs.OrderBookInfo storage info = getOrderBookInfoFromSlot(slot);
+        return aggregate(info.bid, key);
+    }
+
     function subtreeRemoved(
         MarketStructs.OrderBookSideInfo storage info,
         MarketStructs.OrderBookInfo storage orderBookInfo,
         uint40 key
-    ) internal {
+    ) private {
         info.orderInfos[key].executionId = orderBookInfo.seqExecutionId;
+    }
+
+    function subtreeRemovedAsk(uint40 key, uint256 slot) private {
+        MarketStructs.OrderBookInfo storage info = getOrderBookInfoFromSlot(slot);
+        return subtreeRemoved(info.ask, info, key);
+    }
+
+    function subtreeRemovedBid(uint40 key, uint256 slot) private {
+        MarketStructs.OrderBookInfo storage info = getOrderBookInfoFromSlot(slot);
+        return subtreeRemoved(info.bid, info, key);
     }
 
     function _getQuote(MarketStructs.OrderBookSideInfo storage info, uint40 key) private view returns (uint256) {
@@ -169,14 +207,12 @@ library OrderBookLibrary {
     }
 
     function swap(
-        MarketStructs.OrderBookSideInfo storage info,
         MarketStructs.OrderBookInfo storage orderBookInfo,
         PreviewSwapParams memory params,
         function(bool, bool, uint256) view returns (uint256) maxSwapArg,
-        function(bool, bool, uint256) returns (uint256) swap,
-        function(uint40) returns (bool) aggregateArg,
-        function(uint40) subtreeRemovedArg
+        function(bool, bool, uint256) returns (uint256) swap
     ) internal returns (SwapResponse memory swapResponse) {
+        MarketStructs.OrderBookSideInfo storage info = params.isBaseToQuote ? orderBookInfo.bid : orderBookInfo.ask;
         PreviewSwapResponse memory response = previewSwap(info, params, maxSwapArg);
 
         if (response.amountPool > 0) {
@@ -184,17 +220,19 @@ library OrderBookLibrary {
         }
 
         bool isBase = params.isBaseToQuote == params.isExactInput;
+        uint256 slot = getSlot(orderBookInfo);
+
         if (response.fullLastKey != 0) {
             orderBookInfo.seqExecutionId += 1;
             orderBookInfo.executionInfos[orderBookInfo.seqExecutionId] = MarketStructs.ExecutionInfo({
                 baseBalancePerShareX96: params.baseBalancePerShareX96
             });
-            info.tree.removeLeft(
-                response.fullLastKey,
-                params.isBaseToQuote ? lessThanBid : lessThanAsk,
-                aggregateArg,
-                subtreeRemovedArg
-            );
+            if (params.isBaseToQuote) {
+                info.tree.removeLeft(response.fullLastKey, lessThanBid, aggregateBid, subtreeRemovedBid, slot);
+            } else {
+                info.tree.removeLeft(response.fullLastKey, lessThanAsk, aggregateAsk, subtreeRemovedAsk, slot);
+            }
+
             swapResponse.oppositeAmount += isBase ? response.quoteFull : response.baseFull;
         } else {
             require(response.baseFull == 0, "never occur");
@@ -203,7 +241,11 @@ library OrderBookLibrary {
 
         if (response.partialKey != 0) {
             info.orderInfos[response.partialKey].base -= response.basePartial; // result > 0
-            info.tree.aggregateRecursively(response.partialKey, aggregateArg);
+            info.tree.aggregateRecursively(
+                response.partialKey,
+                params.isBaseToQuote ? aggregateBid : aggregateAsk,
+                slot
+            );
 
             swapResponse.oppositeAmount += isBase ? response.quotePartial : response.basePartial;
             swapResponse.basePartial = response.basePartial;
@@ -345,6 +387,18 @@ library OrderBookLibrary {
         if (!isBase) {
             // share * price * baseBalancePerShareX96 = share * share_price
             amount = PRBMath.mulDiv(amount, baseBalancePerShareX96, FixedPoint96.Q96);
+        }
+    }
+
+    function getSlot(MarketStructs.OrderBookInfo storage d) private pure returns (uint256 slot) {
+        assembly {
+            slot := d.slot
+        }
+    }
+
+    function getOrderBookInfoFromSlot(uint256 slot) private pure returns (MarketStructs.OrderBookInfo storage d) {
+        assembly {
+            d.slot := slot
         }
     }
 }

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -24,18 +24,6 @@ library OrderBookLibrary {
     using SignedSafeMath for int256;
     using RBTreeLibrary for RBTreeLibrary.Tree;
 
-    struct OrderInfo {
-        uint256 base;
-        uint256 baseSum;
-        uint256 quoteSum;
-    }
-
-    struct OrderBookSideInfo {
-        RBTreeLibrary.Tree tree;
-        uint40 seqKey;
-        mapping(uint40 => OrderInfo) orderInfos;
-    }
-
     struct PreviewSwapResponse {
         uint256 basePool;
         uint256 quotePool;
@@ -47,7 +35,7 @@ library OrderBookLibrary {
     }
 
     function createOrder(
-        OrderBookSideInfo storage info,
+        MarketStructs.OrderBookSideInfo storage info,
         uint256 base,
         uint256 priceX96,
         function(uint40, uint40) view returns (bool) lessThanArg,
@@ -62,7 +50,7 @@ library OrderBookLibrary {
     }
 
     function cancelOrder(
-        OrderBookSideInfo storage info,
+        MarketStructs.OrderBookSideInfo storage info,
         uint40 key,
         function(uint40) returns (bool) aggregateArg
     ) internal {
@@ -71,7 +59,7 @@ library OrderBookLibrary {
         delete info.orderInfos[key];
     }
 
-    function getOrderInfo(OrderBookSideInfo storage info, uint40 key)
+    function getOrderInfo(MarketStructs.OrderBookSideInfo storage info, uint40 key)
         internal
         view
         returns (
@@ -85,8 +73,8 @@ library OrderBookLibrary {
         // TODO: implement
     }
 
-    function isExecuted(OrderBookSideInfo storage info, uint40 key) internal view returns (bool) {
-        require(info.tree.exists(key), "not exist");
+    function isExecuted(MarketStructs.OrderBookSideInfo storage info, uint40 key) internal view returns (bool) {
+        require(info.tree.exists(key), "OBL_IE: not exist");
         while (key != 0) {
             if (key == info.tree.root) {
                 return false;
@@ -109,7 +97,7 @@ library OrderBookLibrary {
     }
 
     function lessThan(
-        OrderBookSideInfo storage info,
+        MarketStructs.OrderBookSideInfo storage info,
         bool isBid,
         uint40 key0,
         uint40 key1
@@ -123,7 +111,7 @@ library OrderBookLibrary {
         return isBid ? price0 > price1 : price0 < price1;
     }
 
-    function aggregate(OrderBookSideInfo storage info, uint40 key) internal returns (bool stop) {
+    function aggregate(MarketStructs.OrderBookSideInfo storage info, uint40 key) internal returns (bool stop) {
         uint256 prevBaseSum = info.orderInfos[key].baseSum;
         uint256 prevQuoteSum = info.orderInfos[key].quoteSum;
 
@@ -142,7 +130,7 @@ library OrderBookLibrary {
         stop = baseSum == prevBaseSum && quoteSum == prevQuoteSum;
     }
 
-    function _getQuote(OrderBookSideInfo storage info, uint40 key) private view returns (uint256) {
+    function _getQuote(MarketStructs.OrderBookSideInfo storage info, uint40 key) private view returns (uint256) {
         uint128 priceX96 = userDataToPriceX96(info.tree.nodes[key].userData);
         return PRBMath.mulDiv(info.orderInfos[key].base, priceX96, FixedPoint96.Q96);
     }
@@ -155,7 +143,7 @@ library OrderBookLibrary {
     }
 
     function swap(
-        OrderBookSideInfo storage info,
+        MarketStructs.OrderBookSideInfo storage info,
         SwapParams memory params,
         function(bool, bool, uint256) view returns (uint256, uint256) maxSwapBaseQuote,
         function(bool, bool, uint256) returns (uint256) swap,
@@ -203,7 +191,7 @@ library OrderBookLibrary {
     }
 
     function previewSwap(
-        OrderBookSideInfo storage info,
+        MarketStructs.OrderBookSideInfo storage info,
         bool isBaseToQuote,
         bool isExactInput,
         uint256 amount,
@@ -271,7 +259,7 @@ library OrderBookLibrary {
     }
 
     function maxSwap(
-        OrderBookSideInfo storage info,
+        MarketStructs.OrderBookSideInfo storage info,
         bool isBaseToQuote,
         bool isExactInput,
         uint256 priceBoundX96

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -195,7 +195,7 @@ library OrderBookLibrary {
         uint256 baseSum;
         uint256 quoteSum;
 
-        while (true) {
+        while (key != 0) {
             PreviewSwapLocalVars memory vars;
             vars.priceX96 = userDataToPriceX96(info.tree.nodes[key].userData);
             vars.sharePriceX96 = PRBMath.mulDiv(vars.priceX96, params.baseBalancePerShareX96, FixedPoint96.Q96);
@@ -217,10 +217,10 @@ library OrderBookLibrary {
                 ) +
                     vars.amountPool
             ) {
-                key = info.tree.nodes[key].left;
-                if (key == 0) {
+                if (vars.left == 0) {
                     response.fullLastKey = info.tree.prev(key);
                 }
+                key = vars.left;
             } else if (
                 params.amount <=
                 (
@@ -246,10 +246,11 @@ library OrderBookLibrary {
             } else {
                 baseSum = vars.rightBaseSum;
                 quoteSum = vars.rightQuoteSum;
-                key = info.tree.nodes[key].right;
-                if (key == 0) {
+                uint40 right = info.tree.nodes[key].right;
+                if (right == 0) {
                     response.fullLastKey = key;
                 }
+                key = right;
             }
         }
 

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import { Math } from "../amm/uniswap_v2/libraries/Math.sol";
+import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";
+import { SignedSafeMath } from "@openzeppelin/contracts/utils/math/SignedSafeMath.sol";
+import { PerpMath } from "./PerpMath.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import { MarketStructs } from "./MarketStructs.sol";
+import { PRBMath } from "prb-math/contracts/PRBMath.sol";
+import { FixedPoint96 } from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
+import { FullMath } from "./FullMath.sol";
+import {
+    BokkyPooBahsRedBlackTreeLibrary as RBTreeLibrary
+} from "../../deps/BokkyPooBahsRedBlackTreeLibrary/contracts/BokkyPooBahsRedBlackTreeLibrary.sol";
+
+library OrderBookLibrary {
+    using PerpMath for int256;
+    using PerpMath for uint256;
+    using SafeCast for int256;
+    using SafeCast for uint256;
+    using SafeMath for uint256;
+    using SignedSafeMath for int256;
+    using RBTreeLibrary for RBTreeLibrary.Tree;
+
+    struct OrderInfo {
+        uint256 base;
+        uint256 baseSum;
+        uint256 quoteSum;
+    }
+
+    struct OrderBookSideInfo {
+        RBTreeLibrary.Tree tree;
+        uint40 seqKey;
+        mapping(uint40 => OrderInfo) orderInfos;
+    }
+
+    function createOrder(
+        OrderBookSideInfo storage info,
+        uint256 base,
+        uint256 priceX96,
+        function(uint40, uint40) view returns (bool) lessThanArg,
+        function(uint40) returns (bool) aggregateArg
+    ) internal returns (uint40) {
+        uint40 key = info.seqKey + 1;
+        info.seqKey = key;
+        info.tree.insert(key, lessThanArg, aggregateArg);
+        info.tree.nodes[key].userData = makeUserData(priceX96);
+        info.orderInfos[key].base = base;
+        return key;
+    }
+
+    function cancelOrder(
+        OrderBookSideInfo storage info,
+        uint40 key,
+        function(uint40) returns (bool) aggregateArg
+    ) internal {
+        require(!isExecuted(info, key), "already executed");
+        info.tree.remove(key, aggregateArg);
+        delete info.orderInfos[key];
+    }
+
+    function getOrderInfo(OrderBookSideInfo storage info, uint40 key)
+        internal
+        view
+        returns (
+            bool fullyExecuted,
+            int256 executedBase,
+            int256 executedQuote
+        )
+    {
+        fullyExecuted = isExecuted(info, key);
+
+        // TODO: implement
+    }
+
+    function isExecuted(OrderBookSideInfo storage info, uint40 key) internal view returns (bool) {
+        require(info.tree.exists(key), "not exist");
+        while (key != 0) {
+            // TODO: use EMPTY
+            if (key == info.tree.root) {
+                return false;
+            }
+            uint40 parent = info.tree.nodes[key].parent;
+            if (info.tree.nodes[parent].left != key && info.tree.nodes[parent].right != key) {
+                return true;
+            }
+            key = parent;
+        }
+        return true;
+    }
+
+    function makeUserData(uint256 priceX96) internal pure returns (uint128) {
+        return priceX96.toUint128();
+    }
+
+    function userDataToPriceX96(uint128 userData) internal pure returns (uint128) {
+        return userData;
+    }
+
+    function lessThan(
+        OrderBookSideInfo storage info,
+        bool isBid,
+        uint40 key0,
+        uint40 key1
+    ) internal view returns (bool) {
+        uint128 price0 = userDataToPriceX96(info.tree.nodes[key0].userData);
+        uint128 price1 = userDataToPriceX96(info.tree.nodes[key1].userData);
+        if (price0 == price1) {
+            return key0 < key1; // time priority
+        }
+        // price priority
+        return isBid ? price0 > price1 : price0 < price1;
+    }
+
+    function aggregate(OrderBookSideInfo storage info, uint40 key) internal returns (bool stop) {
+        uint256 prevBaseSum = info.orderInfos[key].baseSum;
+        uint256 prevQuoteSum = info.orderInfos[key].quoteSum;
+
+        uint128 priceX96 = userDataToPriceX96(info.tree.nodes[key].userData);
+        uint256 baseSum =
+            info.orderInfos[info.tree.nodes[key].left].baseSum +
+                info.orderInfos[info.tree.nodes[key].right].baseSum +
+                info.orderInfos[key].base;
+        uint256 quoteSum =
+            info.orderInfos[info.tree.nodes[key].left].quoteSum +
+                info.orderInfos[info.tree.nodes[key].right].quoteSum +
+                PRBMath.mulDiv(info.orderInfos[key].base, priceX96, FixedPoint96.Q96);
+
+        info.orderInfos[key].baseSum = baseSum;
+        info.orderInfos[key].quoteSum = quoteSum;
+        stop = baseSum == prevBaseSum && quoteSum == prevQuoteSum;
+    }
+
+    function previewSwap(
+        OrderBookSideInfo storage info,
+        bool isBaseToQuote,
+        bool isExactInput,
+        uint256 amount,
+        bool noRevert,
+        function(bool, bool, uint256) view returns (uint256) poolPreviewSwap
+    ) internal view returns (uint256) {
+        return poolPreviewSwap(isBaseToQuote, isExactInput, amount);
+    }
+
+    function maxSwap(
+        OrderBookSideInfo storage info,
+        bool isBaseToQuote,
+        bool isExactInput,
+        uint256 priceBoundX96
+    ) internal view returns (uint256) {
+        return 0;
+    }
+}

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -209,7 +209,7 @@ library OrderBookLibrary {
             vars.rightQuoteSum = vars.leftQuoteSum + _getQuote(info, key);
 
             if (
-                params.amount <
+                params.amount <=
                 (
                     isBase
                         ? vars.leftBaseSum
@@ -222,7 +222,7 @@ library OrderBookLibrary {
                 }
                 key = vars.left;
             } else if (
-                params.amount <=
+                params.amount <
                 (
                     isBase
                         ? vars.rightBaseSum

--- a/contracts/lib/OrderBookLibrary.sol
+++ b/contracts/lib/OrderBookLibrary.sol
@@ -90,12 +90,6 @@ library OrderBookLibrary {
             orderBookInfo.executionInfos[executionId].baseBalancePerShareX96,
             FixedPoint96.Q96
         );
-
-        // TODO: implement
-
-        // TODO: handle partial execution immediate settlement
-        // force settle partial executed order
-        // TODO: global max order count
     }
 
     function isFullyExecuted(MarketStructs.OrderBookSideInfo storage info, uint40 key) private view returns (uint48) {

--- a/contracts/lib/PerpdexStructs.sol
+++ b/contracts/lib/PerpdexStructs.sol
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity >=0.7.6;
 
+import {
+    BokkyPooBahsRedBlackTreeLibrary as RBTreeLibrary
+} from "../../deps/BokkyPooBahsRedBlackTreeLibrary/contracts/BokkyPooBahsRedBlackTreeLibrary.sol";
+
 library PerpdexStructs {
     struct TakerInfo {
         int256 baseBalanceShare;
@@ -14,10 +18,8 @@ library PerpdexStructs {
     }
 
     struct LimitOrderInfo {
-        uint256 orderId;
-        int256 settledBaseShare;
-        int256 settledQuote;
-        bool isBid;
+        RBTreeLibrary.Tree ask;
+        RBTreeLibrary.Tree bid;
     }
 
     struct VaultInfo {
@@ -30,7 +32,7 @@ library PerpdexStructs {
         // market
         mapping(address => MakerInfo) makerInfos;
         // market
-        mapping(address => LimitOrderInfo[]) limitOrderInfos;
+        mapping(address => LimitOrderInfo) limitOrderInfos;
         VaultInfo vaultInfo;
         address[] markets;
     }

--- a/contracts/lib/PerpdexStructs.sol
+++ b/contracts/lib/PerpdexStructs.sol
@@ -13,6 +13,13 @@ library PerpdexStructs {
         uint256 cumQuotePerLiquidityX96;
     }
 
+    struct LimitOrderInfo {
+        uint256 orderId;
+        int256 settledBaseShare;
+        int256 settledQuote;
+        bool isBid;
+    }
+
     struct VaultInfo {
         int256 collateralBalance;
     }
@@ -22,6 +29,8 @@ library PerpdexStructs {
         mapping(address => TakerInfo) takerInfos;
         // market
         mapping(address => MakerInfo) makerInfos;
+        // market
+        mapping(address => LimitOrderInfo[]) limitOrderInfos;
         VaultInfo vaultInfo;
         address[] markets;
     }

--- a/contracts/lib/TakerLibrary.sol
+++ b/contracts/lib/TakerLibrary.sol
@@ -54,6 +54,7 @@ library TakerLibrary {
         uint256 liquidationReward;
         uint256 insuranceFundReward;
         bool isLiquidation;
+        IPerpdexMarketMinimum.SwapResponse rawResponse;
     }
 
     function trade(
@@ -75,17 +76,19 @@ library TakerLibrary {
 
         int256 takerBaseBefore = accountInfo.takerInfos[params.market].baseBalanceShare;
 
-        (response.base, response.quote, response.realizedPnl, response.protocolFee) = _doSwap(
+        (response.base, response.quote, response.realizedPnl, response.protocolFee, response.rawResponse) = _doSwap(
             accountInfo,
             protocolInfo,
-            params.market,
-            params.isBaseToQuote,
-            params.isExactInput,
-            params.amount,
-            params.oppositeAmountBound,
-            params.maxMarketsPerAccount,
-            params.protocolFeeRatio,
-            response.isLiquidation
+            DoSwapParams({
+                market: params.market,
+                isBaseToQuote: params.isBaseToQuote,
+                isExactInput: params.isExactInput,
+                amount: params.amount,
+                oppositeAmountBound: params.oppositeAmountBound,
+                maxMarketsPerAccount: params.maxMarketsPerAccount,
+                protocolFeeRatio: params.protocolFeeRatio,
+                isLiquidation: response.isLiquidation
+            })
         );
 
         bool isOpen = (takerBaseBefore.add(response.base)).sign() * response.base.sign() > 0;
@@ -198,47 +201,62 @@ library TakerLibrary {
         }
     }
 
+    // to avoid stack too deep
+    struct DoSwapParams {
+        address market;
+        bool isBaseToQuote;
+        bool isExactInput;
+        uint256 amount;
+        uint256 oppositeAmountBound;
+        uint8 maxMarketsPerAccount;
+        uint24 protocolFeeRatio;
+        bool isLiquidation;
+    }
+
     function _doSwap(
         PerpdexStructs.AccountInfo storage accountInfo,
         PerpdexStructs.ProtocolInfo storage protocolInfo,
-        address market,
-        bool isBaseToQuote,
-        bool isExactInput,
-        uint256 amount,
-        uint256 oppositeAmountBound,
-        uint8 maxMarketsPerAccount,
-        uint24 protocolFeeRatio,
-        bool isLiquidation
+        DoSwapParams memory params
     )
         private
         returns (
             int256 base,
             int256 quote,
             int256 realizedPnl,
-            uint256 protocolFee
+            uint256 protocolFee,
+            IPerpdexMarketMinimum.SwapResponse memory rawResponse
         )
     {
         uint256 oppositeAmount;
 
-        if (protocolFeeRatio > 0) {
-            (oppositeAmount, protocolFee) = swapWithProtocolFee(
+        if (params.protocolFeeRatio > 0) {
+            (oppositeAmount, protocolFee, rawResponse) = swapWithProtocolFee(
                 protocolInfo,
-                market,
-                isBaseToQuote,
-                isExactInput,
-                amount,
-                protocolFeeRatio,
-                isLiquidation
+                params.market,
+                params.isBaseToQuote,
+                params.isExactInput,
+                params.amount,
+                params.protocolFeeRatio,
+                params.isLiquidation
             );
         } else {
-            oppositeAmount = IPerpdexMarketMinimum(market)
-                .swap(isBaseToQuote, isExactInput, amount, isLiquidation)
-                .oppositeAmount;
+            rawResponse = IPerpdexMarketMinimum(params.market).swap(
+                params.isBaseToQuote,
+                params.isExactInput,
+                params.amount,
+                params.isLiquidation
+            );
+            oppositeAmount = rawResponse.oppositeAmount;
         }
-        validateSlippage(isExactInput, oppositeAmount, oppositeAmountBound);
+        validateSlippage(params.isExactInput, oppositeAmount, params.oppositeAmountBound);
 
-        (base, quote) = swapResponseToBaseQuote(isBaseToQuote, isExactInput, amount, oppositeAmount);
-        realizedPnl = addToTakerBalance(accountInfo, market, base, quote, 0, maxMarketsPerAccount);
+        (base, quote) = swapResponseToBaseQuote(
+            params.isBaseToQuote,
+            params.isExactInput,
+            params.amount,
+            oppositeAmount
+        );
+        realizedPnl = addToTakerBalance(accountInfo, params.market, base, quote, 0, params.maxMarketsPerAccount);
     }
 
     function swapWithProtocolFee(
@@ -249,31 +267,43 @@ library TakerLibrary {
         uint256 amount,
         uint24 protocolFeeRatio,
         bool isLiquidation
-    ) internal returns (uint256 oppositeAmount, uint256 protocolFee) {
+    )
+        internal
+        returns (
+            uint256 oppositeAmount,
+            uint256 protocolFee,
+            IPerpdexMarketMinimum.SwapResponse memory rawResponse
+        )
+    {
         if (isExactInput) {
             if (isBaseToQuote) {
-                oppositeAmount = IPerpdexMarketMinimum(market)
-                    .swap(isBaseToQuote, isExactInput, amount, isLiquidation)
-                    .oppositeAmount;
+                rawResponse = IPerpdexMarketMinimum(market).swap(isBaseToQuote, isExactInput, amount, isLiquidation);
+                oppositeAmount = rawResponse.oppositeAmount;
                 protocolFee = oppositeAmount.mulRatio(protocolFeeRatio);
                 oppositeAmount = oppositeAmount.sub(protocolFee);
             } else {
                 protocolFee = amount.mulRatio(protocolFeeRatio);
-                oppositeAmount = IPerpdexMarketMinimum(market)
-                    .swap(isBaseToQuote, isExactInput, amount.sub(protocolFee), isLiquidation)
-                    .oppositeAmount;
+                rawResponse = IPerpdexMarketMinimum(market).swap(
+                    isBaseToQuote,
+                    isExactInput,
+                    amount.sub(protocolFee),
+                    isLiquidation
+                );
+                oppositeAmount = rawResponse.oppositeAmount;
             }
         } else {
             if (isBaseToQuote) {
                 protocolFee = amount.divRatio(PerpMath.subRatio(1e6, protocolFeeRatio)).sub(amount);
-                oppositeAmount = IPerpdexMarketMinimum(market)
-                    .swap(isBaseToQuote, isExactInput, amount.add(protocolFee), isLiquidation)
-                    .oppositeAmount;
+                rawResponse = IPerpdexMarketMinimum(market).swap(
+                    isBaseToQuote,
+                    isExactInput,
+                    amount.add(protocolFee),
+                    isLiquidation
+                );
+                oppositeAmount = rawResponse.oppositeAmount;
             } else {
-                uint256 oppositeAmountWithoutFee =
-                    IPerpdexMarketMinimum(market)
-                        .swap(isBaseToQuote, isExactInput, amount, isLiquidation)
-                        .oppositeAmount;
+                rawResponse = IPerpdexMarketMinimum(market).swap(isBaseToQuote, isExactInput, amount, isLiquidation);
+                uint256 oppositeAmountWithoutFee = rawResponse.oppositeAmount;
                 oppositeAmount = oppositeAmountWithoutFee.divRatio(PerpMath.subRatio(1e6, protocolFeeRatio));
                 protocolFee = oppositeAmount.sub(oppositeAmountWithoutFee);
             }

--- a/contracts/lib/TakerLibrary.sol
+++ b/contracts/lib/TakerLibrary.sol
@@ -231,7 +231,9 @@ library TakerLibrary {
                 isLiquidation
             );
         } else {
-            oppositeAmount = IPerpdexMarketMinimum(market).swap(isBaseToQuote, isExactInput, amount, isLiquidation);
+            oppositeAmount = IPerpdexMarketMinimum(market)
+                .swap(isBaseToQuote, isExactInput, amount, isLiquidation)
+                .oppositeAmount;
         }
         validateSlippage(isExactInput, oppositeAmount, oppositeAmountBound);
 
@@ -250,30 +252,28 @@ library TakerLibrary {
     ) internal returns (uint256 oppositeAmount, uint256 protocolFee) {
         if (isExactInput) {
             if (isBaseToQuote) {
-                oppositeAmount = IPerpdexMarketMinimum(market).swap(isBaseToQuote, isExactInput, amount, isLiquidation);
+                oppositeAmount = IPerpdexMarketMinimum(market)
+                    .swap(isBaseToQuote, isExactInput, amount, isLiquidation)
+                    .oppositeAmount;
                 protocolFee = oppositeAmount.mulRatio(protocolFeeRatio);
                 oppositeAmount = oppositeAmount.sub(protocolFee);
             } else {
                 protocolFee = amount.mulRatio(protocolFeeRatio);
-                oppositeAmount = IPerpdexMarketMinimum(market).swap(
-                    isBaseToQuote,
-                    isExactInput,
-                    amount.sub(protocolFee),
-                    isLiquidation
-                );
+                oppositeAmount = IPerpdexMarketMinimum(market)
+                    .swap(isBaseToQuote, isExactInput, amount.sub(protocolFee), isLiquidation)
+                    .oppositeAmount;
             }
         } else {
             if (isBaseToQuote) {
                 protocolFee = amount.divRatio(PerpMath.subRatio(1e6, protocolFeeRatio)).sub(amount);
-                oppositeAmount = IPerpdexMarketMinimum(market).swap(
-                    isBaseToQuote,
-                    isExactInput,
-                    amount.add(protocolFee),
-                    isLiquidation
-                );
+                oppositeAmount = IPerpdexMarketMinimum(market)
+                    .swap(isBaseToQuote, isExactInput, amount.add(protocolFee), isLiquidation)
+                    .oppositeAmount;
             } else {
                 uint256 oppositeAmountWithoutFee =
-                    IPerpdexMarketMinimum(market).swap(isBaseToQuote, isExactInput, amount, isLiquidation);
+                    IPerpdexMarketMinimum(market)
+                        .swap(isBaseToQuote, isExactInput, amount, isLiquidation)
+                        .oppositeAmount;
                 oppositeAmount = oppositeAmountWithoutFee.divRatio(PerpMath.subRatio(1e6, protocolFeeRatio));
                 protocolFee = oppositeAmount.sub(oppositeAmountWithoutFee);
             }

--- a/contracts/test/DebugPerpdexExchange.sol
+++ b/contracts/test/DebugPerpdexExchange.sol
@@ -12,6 +12,7 @@ contract DebugPerpdexExchange is PerpdexExchange {
     uint256 private constant _ZKSYNC2_TESTNET_CHAIN_ID = 0;
     uint256 private constant _ARBITRUM_RINKEBY_CHAIN_ID = 421611;
     uint256 private constant _OPTIMISM_KOVAN_CHAIN_ID = 69;
+    uint256 private constant _HARDHAT_CHAIN_ID = 31337;
 
     constructor(address settlementTokenArg) PerpdexExchange(settlementTokenArg) {
         uint256 chainId;
@@ -24,7 +25,8 @@ contract DebugPerpdexExchange is PerpdexExchange {
                 chainId == _SHIBUYA_CHAIN_ID ||
                 chainId == _ZKSYNC2_TESTNET_CHAIN_ID ||
                 chainId == _ARBITRUM_RINKEBY_CHAIN_ID ||
-                chainId == _OPTIMISM_KOVAN_CHAIN_ID,
+                chainId == _OPTIMISM_KOVAN_CHAIN_ID ||
+                chainId == _HARDHAT_CHAIN_ID,
             "DPE_C: testnet only"
         );
     }

--- a/contracts/test/TestOrderBookLibrary.sol
+++ b/contracts/test/TestOrderBookLibrary.sol
@@ -11,8 +11,7 @@ import { MarketStructs } from "../lib/MarketStructs.sol";
 contract TestOrderBookLibrary {
     constructor() {}
 
-    MarketStructs.OrderBookSideInfo ask;
-    MarketStructs.OrderBookSideInfo bid;
+    MarketStructs.OrderBookInfo info;
 
     function previewSwap(
         bool isBaseToQuote,
@@ -21,7 +20,7 @@ contract TestOrderBookLibrary {
         uint256 baseBalancePerShareX96
     ) external view returns (OrderBookLibrary.PreviewSwapResponse memory response) {
         response = OrderBookLibrary.previewSwap(
-            isBaseToQuote ? bid : ask,
+            isBaseToQuote ? info.bid : info.ask,
             OrderBookLibrary.PreviewSwapParams({
                 isBaseToQuote: isBaseToQuote,
                 isExactInput: isExactInput,
@@ -64,7 +63,7 @@ contract TestOrderBookLibrary {
     ) external view returns (uint256 amount) {
         return
             OrderBookLibrary.maxSwap(
-                isBaseToQuote ? bid : ask,
+                isBaseToQuote ? info.bid : info.ask,
                 isBaseToQuote,
                 isExactInput,
                 sharePriceBoundX96,
@@ -85,18 +84,6 @@ contract TestOrderBookLibrary {
     }
 
     function createOrder(CreateOrderParams calldata params) private {
-        if (params.isBid) {
-            OrderBookLibrary.createOrder(bid, true, params.base, params.priceX96, orderBookAggregateBid);
-        } else {
-            OrderBookLibrary.createOrder(ask, false, params.base, params.priceX96, orderBookAggregateAsk);
-        }
-    }
-
-    function orderBookAggregateAsk(uint40 key) private returns (bool stop) {
-        return OrderBookLibrary.aggregate(ask, key);
-    }
-
-    function orderBookAggregateBid(uint40 key) private returns (bool stop) {
-        return OrderBookLibrary.aggregate(bid, key);
+        OrderBookLibrary.createOrder(info, params.isBid, params.base, params.priceX96);
     }
 }

--- a/contracts/test/TestOrderBookLibrary.sol
+++ b/contracts/test/TestOrderBookLibrary.sol
@@ -86,30 +86,10 @@ contract TestOrderBookLibrary {
 
     function createOrder(CreateOrderParams calldata params) private {
         if (params.isBid) {
-            OrderBookLibrary.createOrder(
-                bid,
-                params.base,
-                params.priceX96,
-                orderBookLessThanBid,
-                orderBookAggregateBid
-            );
+            OrderBookLibrary.createOrder(bid, true, params.base, params.priceX96, orderBookAggregateBid);
         } else {
-            OrderBookLibrary.createOrder(
-                ask,
-                params.base,
-                params.priceX96,
-                orderBookLessThanAsk,
-                orderBookAggregateAsk
-            );
+            OrderBookLibrary.createOrder(ask, false, params.base, params.priceX96, orderBookAggregateAsk);
         }
-    }
-
-    function orderBookLessThanAsk(uint40 key0, uint40 key1) private view returns (bool) {
-        return OrderBookLibrary.lessThan(ask, false, key0, key1);
-    }
-
-    function orderBookLessThanBid(uint40 key0, uint40 key1) private view returns (bool) {
-        return OrderBookLibrary.lessThan(bid, true, key0, key1);
     }
 
     function orderBookAggregateAsk(uint40 key) private returns (bool stop) {

--- a/contracts/test/TestOrderBookLibrary.sol
+++ b/contracts/test/TestOrderBookLibrary.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity >=0.7.6;
+pragma abicoder v2;
+
+import { PoolLibrary } from "../lib/PoolLibrary.sol";
+import { OrderBookLibrary } from "../lib/OrderBookLibrary.sol";
+import { MarketStructs } from "../lib/MarketStructs.sol";
+
+contract TestOrderBookLibrary {
+    constructor() {}
+
+    MarketStructs.OrderBookSideInfo ask;
+    MarketStructs.OrderBookSideInfo bid;
+
+    function maxSwap(
+        bool isBaseToQuote,
+        bool isExactInput,
+        uint256 priceBoundX96
+    ) external view returns (uint256 amount) {
+        return OrderBookLibrary.maxSwap(isBaseToQuote ? bid : ask, isBaseToQuote, isExactInput, priceBoundX96);
+    }
+
+    struct CreateOrderParams {
+        bool isBid;
+        uint256 base;
+        uint256 priceX96;
+    }
+
+    function createOrders(CreateOrderParams[] calldata params) external {
+        for (uint256 i = 0; i < params.length; ++i) {
+            createOrder(params[i]);
+        }
+    }
+
+    function createOrder(CreateOrderParams calldata params) private {
+        if (params.isBid) {
+            OrderBookLibrary.createOrder(
+                bid,
+                params.base,
+                params.priceX96,
+                orderBookLessThanBid,
+                orderBookAggregateBid
+            );
+        } else {
+            OrderBookLibrary.createOrder(
+                ask,
+                params.base,
+                params.priceX96,
+                orderBookLessThanAsk,
+                orderBookAggregateAsk
+            );
+        }
+    }
+
+    function orderBookLessThanAsk(uint40 key0, uint40 key1) private view returns (bool) {
+        return OrderBookLibrary.lessThan(ask, false, key0, key1);
+    }
+
+    function orderBookLessThanBid(uint40 key0, uint40 key1) private view returns (bool) {
+        return OrderBookLibrary.lessThan(bid, true, key0, key1);
+    }
+
+    function orderBookAggregateAsk(uint40 key) private returns (bool stop) {
+        return OrderBookLibrary.aggregate(ask, key);
+    }
+
+    function orderBookAggregateBid(uint40 key) private returns (bool stop) {
+        return OrderBookLibrary.aggregate(bid, key);
+    }
+}

--- a/contracts/test/TestOrderBookLibrary.sol
+++ b/contracts/test/TestOrderBookLibrary.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.7.6;
 pragma abicoder v2;
 
+import { FixedPoint96 } from "@uniswap/v3-core/contracts/libraries/FixedPoint96.sol";
+import { PRBMath } from "prb-math/contracts/PRBMath.sol";
 import { PoolLibrary } from "../lib/PoolLibrary.sol";
 import { OrderBookLibrary } from "../lib/OrderBookLibrary.sol";
 import { MarketStructs } from "../lib/MarketStructs.sol";
@@ -12,12 +14,62 @@ contract TestOrderBookLibrary {
     MarketStructs.OrderBookSideInfo ask;
     MarketStructs.OrderBookSideInfo bid;
 
+    function previewSwap(
+        bool isBaseToQuote,
+        bool isExactInput,
+        uint256 amount,
+        uint256 baseBalancePerShareX96
+    ) external view returns (OrderBookLibrary.PreviewSwapResponse memory response) {
+        response = OrderBookLibrary.previewSwap(
+            isBaseToQuote ? bid : ask,
+            OrderBookLibrary.PreviewSwapParams({
+                isBaseToQuote: isBaseToQuote,
+                isExactInput: isExactInput,
+                amount: amount,
+                noRevert: false,
+                baseBalancePerShareX96: baseBalancePerShareX96
+            }),
+            poolMaxSwap
+        );
+    }
+
+    function poolMaxSwap(
+        bool isBaseToQuote,
+        bool isExactInput,
+        uint256 priceX96
+    ) private view returns (uint256 amount) {
+        uint256 base;
+        if (isBaseToQuote) {
+            if (priceX96 < FixedPoint96.Q96) {
+                base = PRBMath.mulDiv(100, FixedPoint96.Q96 - priceX96, FixedPoint96.Q96);
+            }
+        } else {
+            if (priceX96 > FixedPoint96.Q96) {
+                base = PRBMath.mulDiv(100, priceX96 - FixedPoint96.Q96, FixedPoint96.Q96);
+            }
+        }
+        bool isBase = isBaseToQuote == isExactInput;
+        if (isBase) {
+            amount = base;
+        } else {
+            amount = base * 2;
+        }
+    }
+
     function maxSwap(
         bool isBaseToQuote,
         bool isExactInput,
-        uint256 priceBoundX96
+        uint256 sharePriceBoundX96,
+        uint256 baseBalancePerShareX96
     ) external view returns (uint256 amount) {
-        return OrderBookLibrary.maxSwap(isBaseToQuote ? bid : ask, isBaseToQuote, isExactInput, priceBoundX96);
+        return
+            OrderBookLibrary.maxSwap(
+                isBaseToQuote ? bid : ask,
+                isBaseToQuote,
+                isExactInput,
+                sharePriceBoundX96,
+                baseBalancePerShareX96
+            );
     }
 
     struct CreateOrderParams {

--- a/contracts/test/TestTakerLibrary.sol
+++ b/contracts/test/TestTakerLibrary.sol
@@ -48,7 +48,7 @@ contract TestTakerLibrary {
         uint24 protocolFeeRatio,
         bool isLiquidation
     ) external {
-        (uint256 oppositeAmount, uint256 protocolFee) =
+        (uint256 oppositeAmount, uint256 protocolFee, ) =
             TakerLibrary.swapWithProtocolFee(
                 protocolInfo,
                 market,

--- a/deploy/021_deploy_perpdex_exchange.ts
+++ b/deploy/021_deploy_perpdex_exchange.ts
@@ -17,6 +17,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     const settlementTokenAddress = hre.ethers.constants.AddressZero // native token
 
+    await deploy("AccountLibrary", {
+        from: deployer,
+        log: true,
+        autoMine: true,
+    })
+    const accountLibrary = await deployments.get("AccountLibrary")
+
+    await deploy("MakerOrderBookLibrary", {
+        from: deployer,
+        log: true,
+        autoMine: true,
+        libraries: {
+            AccountLibrary: accountLibrary.address,
+        },
+    })
+    const makerOrderBookLibrary = await deployments.get("MakerOrderBookLibrary")
+
     try {
         await deploy("PerpdexExchange", {
             contract: "DebugPerpdexExchange",
@@ -24,6 +41,10 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
             args: [settlementTokenAddress],
             log: true,
             autoMine: true,
+            libraries: {
+                AccountLibrary: accountLibrary.address,
+                MakerOrderBookLibrary: makerOrderBookLibrary.address,
+            },
         })
     } catch (err) {
         console.log(err.message)

--- a/deploy/031_deploy_perpdex_market.ts
+++ b/deploy/031_deploy_perpdex_market.ts
@@ -16,6 +16,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         zksync2_testnet: "DebugPriceFeedETHUSD",
         arbitrum_rinkeby: "ChainlinkPriceFeedETHUSD",
         optimism_kovan: "ChainlinkPriceFeedETHUSD",
+        hardhat: hre.ethers.constants.AddressZero,
     }[hre.network.name]
 
     const markets = {
@@ -83,7 +84,20 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
                 priceFeedBase: hre.ethers.constants.AddressZero,
             },
         ],
+        hardhat: [
+            {
+                symbol: "USD",
+                priceFeedBase: hre.ethers.constants.AddressZero,
+            },
+        ],
     }[hre.network.name]
+
+    await deploy("OrderBookLibrary", {
+        from: deployer,
+        log: true,
+        autoMine: true,
+    })
+    const orderBookLibrary = await deployments.get("OrderBookLibrary")
 
     const perpdexExchange = await deployments.get("PerpdexExchange")
 
@@ -103,6 +117,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
             ],
             log: true,
             autoMine: true,
+            libraries: {
+                OrderBookLibrary: orderBookLibrary.address,
+            },
         })
 
         await execute(

--- a/test/accountLibrary/fixtures.ts
+++ b/test/accountLibrary/fixtures.ts
@@ -10,7 +10,14 @@ interface AccountLibraryFixture {
 
 export function createAccountLibraryFixture(): (wallets, provider) => Promise<AccountLibraryFixture> {
     return async ([owner, market1, market2], provider): Promise<AccountLibraryFixture> => {
-        const factory = await ethers.getContractFactory("TestAccountLibrary")
+        const accountLibraryFactory = await ethers.getContractFactory("AccountLibrary")
+        const accountLib = await accountLibraryFactory.deploy()
+
+        const factory = await ethers.getContractFactory("TestAccountLibrary", {
+            libraries: {
+                AccountLibrary: accountLib.address,
+            },
+        })
         const accountLibrary = (await factory.deploy()) as TestAccountLibrary
 
         return {

--- a/test/orderBookLibrary/fixtures.ts
+++ b/test/orderBookLibrary/fixtures.ts
@@ -1,0 +1,17 @@
+import { ethers, waffle } from "hardhat"
+import { TestOrderBookLibrary } from "../../typechain"
+
+interface OrderBookLibraryFixture {
+    library: TestOrderBookLibrary
+}
+
+export function createOrderBookLibraryFixture(): (wallets, provider) => Promise<OrderBookLibraryFixture> {
+    return async ([owner], provider): Promise<OrderBookLibraryFixture> => {
+        const factory = await ethers.getContractFactory("TestOrderBookLibrary")
+        const library = (await factory.deploy()) as TestOrderBookLibrary
+
+        return {
+            library,
+        }
+    }
+}

--- a/test/orderBookLibrary/fixtures.ts
+++ b/test/orderBookLibrary/fixtures.ts
@@ -7,7 +7,14 @@ interface OrderBookLibraryFixture {
 
 export function createOrderBookLibraryFixture(): (wallets, provider) => Promise<OrderBookLibraryFixture> {
     return async ([owner], provider): Promise<OrderBookLibraryFixture> => {
-        const factory = await ethers.getContractFactory("TestOrderBookLibrary")
+        const orderBookLibraryFactory = await ethers.getContractFactory("OrderBookLibrary")
+        const orderBookLibrary = await orderBookLibraryFactory.deploy()
+
+        const factory = await ethers.getContractFactory("TestOrderBookLibrary", {
+            libraries: {
+                OrderBookLibrary: orderBookLibrary.address,
+            },
+        })
         const library = (await factory.deploy()) as TestOrderBookLibrary
 
         return {

--- a/test/orderBookLibrary/maxSwap.test.ts
+++ b/test/orderBookLibrary/maxSwap.test.ts
@@ -204,17 +204,72 @@ describe("OrderBookLibrary maxSwap", () => {
                 expected: 300 * 10,
                 expectedExactOutput: 1100 * 10,
             },
+            {
+                title: "baseBalancePerShareX96 long for ask. out of bound",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(2).mul(2).sub(1),
+                baseBalancePerShareX96: Q96.mul(2),
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "baseBalancePerShareX96 long for ask. same price",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(2).mul(2),
+                baseBalancePerShareX96: Q96.mul(2),
+                expected: 400,
+                expectedExactOutput: 100,
+            },
+            {
+                title: "baseBalancePerShareX96 long for ask. in bound",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(2).mul(2).add(1),
+                baseBalancePerShareX96: Q96.mul(2),
+                expected: 400,
+                expectedExactOutput: 100,
+            },
         ].forEach(test => {
             describe(test.title, () => {
                 it("exact input", async () => {
                     await library.createOrders(test.orders)
-                    const result = await library.maxSwap(test.isBaseToQuote, true, test.priceBoundX96)
+                    const result = await library.maxSwap(
+                        test.isBaseToQuote,
+                        true,
+                        test.priceBoundX96,
+                        test.baseBalancePerShareX96 || Q96,
+                    )
                     expect(result).to.eq(test.expected)
                 })
 
                 it("exact output", async () => {
                     await library.createOrders(test.orders)
-                    const result = await library.maxSwap(test.isBaseToQuote, false, test.priceBoundX96)
+                    const result = await library.maxSwap(
+                        test.isBaseToQuote,
+                        false,
+                        test.priceBoundX96,
+                        test.baseBalancePerShareX96 || Q96,
+                    )
                     expect(result).to.eq(test.expectedExactOutput)
                 })
             })

--- a/test/orderBookLibrary/maxSwap.test.ts
+++ b/test/orderBookLibrary/maxSwap.test.ts
@@ -1,0 +1,223 @@
+import { expect } from "chai"
+import { waffle } from "hardhat"
+import { TestOrderBookLibrary } from "../../typechain"
+import { createOrderBookLibraryFixture } from "./fixtures"
+import { BigNumber } from "ethers"
+import _ from "lodash"
+
+describe("OrderBookLibrary maxSwap", () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let library: TestOrderBookLibrary
+
+    const Q96 = BigNumber.from(2).pow(96)
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createOrderBookLibraryFixture())
+        library = fixture.library
+    })
+
+    describe("various cases", () => {
+        ;[
+            {
+                title: "empty long",
+                orders: [],
+                isBaseToQuote: false,
+                priceBoundX96: Q96,
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "empty short",
+                orders: [],
+                isBaseToQuote: true,
+                priceBoundX96: Q96,
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "long for bid",
+                orders: [
+                    {
+                        isBid: true,
+                        base: 100,
+                        priceX96: Q96,
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96,
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "short for ask",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96,
+                    },
+                ],
+                isBaseToQuote: true,
+                priceBoundX96: Q96,
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "long for ask. out of bound",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(2).sub(1),
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "long for ask. same price",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(2),
+                expected: 200,
+                expectedExactOutput: 100,
+            },
+            {
+                title: "long for ask. in bound",
+                orders: [
+                    {
+                        isBid: false,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(2).add(1),
+                expected: 200,
+                expectedExactOutput: 100,
+            },
+            {
+                title: "short for bid. out of bound",
+                orders: [
+                    {
+                        isBid: true,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: true,
+                priceBoundX96: Q96.mul(2).add(1),
+                expected: 0,
+                expectedExactOutput: 0,
+            },
+            {
+                title: "short for bid. same price",
+                orders: [
+                    {
+                        isBid: true,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: true,
+                priceBoundX96: Q96.mul(2),
+                expected: 100,
+                expectedExactOutput: 200,
+            },
+            {
+                title: "short for bid. in bound",
+                orders: [
+                    {
+                        isBid: true,
+                        base: 100,
+                        priceX96: Q96.mul(2),
+                    },
+                ],
+                isBaseToQuote: true,
+                priceBoundX96: Q96.mul(2).sub(1),
+                expected: 100,
+                expectedExactOutput: 200,
+            },
+            {
+                title: "long for ask. complex case",
+                orders: _.flatten(
+                    _.map(_.range(10), () => {
+                        return [
+                            {
+                                isBid: false,
+                                base: 50,
+                                priceX96: Q96.mul(2),
+                            },
+                            {
+                                isBid: false,
+                                base: 100,
+                                priceX96: Q96.mul(3),
+                            },
+                            {
+                                isBid: false,
+                                base: 200,
+                                priceX96: Q96.mul(4),
+                            },
+                        ]
+                    }),
+                ),
+                isBaseToQuote: false,
+                priceBoundX96: Q96.mul(3),
+                expected: 400 * 10,
+                expectedExactOutput: 150 * 10,
+            },
+            {
+                title: "short for bid. complex case",
+                orders: _.flatten(
+                    _.map(_.range(10), () => {
+                        return [
+                            {
+                                isBid: true,
+                                base: 50,
+                                priceX96: Q96.mul(2),
+                            },
+                            {
+                                isBid: true,
+                                base: 100,
+                                priceX96: Q96.mul(3),
+                            },
+                            {
+                                isBid: true,
+                                base: 200,
+                                priceX96: Q96.mul(4),
+                            },
+                        ]
+                    }),
+                ),
+                isBaseToQuote: true,
+                priceBoundX96: Q96.mul(3),
+                expected: 300 * 10,
+                expectedExactOutput: 1100 * 10,
+            },
+        ].forEach(test => {
+            describe(test.title, () => {
+                it("exact input", async () => {
+                    await library.createOrders(test.orders)
+                    const result = await library.maxSwap(test.isBaseToQuote, true, test.priceBoundX96)
+                    expect(result).to.eq(test.expected)
+                })
+
+                it("exact output", async () => {
+                    await library.createOrders(test.orders)
+                    const result = await library.maxSwap(test.isBaseToQuote, false, test.priceBoundX96)
+                    expect(result).to.eq(test.expectedExactOutput)
+                })
+            })
+        })
+    })
+})

--- a/test/orderBookLibrary/previewSwap.test.ts
+++ b/test/orderBookLibrary/previewSwap.test.ts
@@ -1,0 +1,107 @@
+import { expect } from "chai"
+import { waffle } from "hardhat"
+import { TestOrderBookLibrary } from "../../typechain"
+import { createOrderBookLibraryFixture } from "./fixtures"
+import { BigNumber } from "ethers"
+import _ from "lodash"
+
+describe("OrderBookLibrary previewSwap", () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let library: TestOrderBookLibrary
+
+    const Q96 = BigNumber.from(2).pow(96)
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createOrderBookLibraryFixture())
+        library = fixture.library
+    })
+
+    describe("various cases", () => {
+        ;[
+            {
+                title: "amm only long",
+                orders: [],
+                isBaseToQuote: false,
+                tests: [
+                    {
+                        title: "zero",
+                        isExactInput: true,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "zero",
+                        isExactInput: false,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "normal",
+                        isExactInput: true,
+                        amount: 100,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "normal",
+                        isExactInput: false,
+                        amount: 100,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                ],
+            },
+        ].forEach(test => {
+            describe(test.title, () => {
+                test.tests.forEach(subtest => {
+                    describe(subtest.title + subtest.isExactInput ? " exact input" : " exact output", () => {
+                        it("ok", async () => {
+                            await library.createOrders(test.orders)
+                            const result = await library.previewSwap(
+                                test.isBaseToQuote,
+                                subtest.isExactInput,
+                                subtest.amount,
+                                Q96,
+                            )
+                            _.each(subtest.expected, (_value, key) => {
+                                expect(result[key]).to.deep.eq(subtest.expected[key])
+                            })
+                        })
+                    })
+                })
+            })
+        })
+    })
+})

--- a/test/orderBookLibrary/previewSwap.test.ts
+++ b/test/orderBookLibrary/previewSwap.test.ts
@@ -83,10 +83,463 @@ describe("OrderBookLibrary previewSwap", () => {
                     },
                 ],
             },
+            {
+                title: "amm only short",
+                orders: [],
+                isBaseToQuote: true,
+                tests: [
+                    {
+                        title: "zero",
+                        isExactInput: true,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "zero",
+                        isExactInput: false,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "normal",
+                        isExactInput: true,
+                        amount: 100,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "normal",
+                        isExactInput: false,
+                        amount: 100,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                ],
+            },
+            {
+                title: "complex case long",
+                orders: _.flatten(
+                    _.map(_.range(10), () => {
+                        return [
+                            {
+                                isBid: false,
+                                base: 50,
+                                priceX96: Q96.mul(2),
+                            },
+                            {
+                                isBid: false,
+                                base: 100,
+                                priceX96: Q96.mul(3),
+                            },
+                            {
+                                isBid: false,
+                                base: 200,
+                                priceX96: Q96.mul(4),
+                            },
+                        ]
+                    }),
+                ),
+                isBaseToQuote: false,
+                tests: [
+                    {
+                        title: "zero",
+                        isExactInput: true,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "zero",
+                        isExactInput: false,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "amm only",
+                        isExactInput: true,
+                        amount: 200,
+                        expected: {
+                            amountPool: 200,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "amm only",
+                        isExactInput: false,
+                        amount: 100,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "partial",
+                        isExactInput: true,
+                        amount: 250,
+                        expected: {
+                            amountPool: 200,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 25,
+                            quotePartial: 50,
+                            fullLastKey: 0,
+                            partialKey: 1,
+                        },
+                    },
+                    {
+                        title: "partial",
+                        isExactInput: false,
+                        amount: 125,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 25,
+                            quotePartial: 50,
+                            fullLastKey: 0,
+                            partialKey: 1,
+                        },
+                    },
+                    {
+                        title: "full and partial",
+                        isExactInput: true,
+                        amount: 200 + 100 + 10,
+                        expected: {
+                            amountPool: 200,
+                            baseFull: 50,
+                            quoteFull: 100,
+                            basePartial: 5,
+                            quotePartial: 10,
+                            fullLastKey: 1,
+                            partialKey: 4,
+                        },
+                    },
+                    {
+                        title: "full and partial",
+                        isExactInput: false,
+                        amount: 100 + 50 + 10,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 50,
+                            quoteFull: 100,
+                            basePartial: 10,
+                            quotePartial: 20,
+                            fullLastKey: 1,
+                            partialKey: 4,
+                        },
+                    },
+                    {
+                        title: "between order",
+                        isExactInput: true,
+                        amount: 200 + 100 * 10 + 10,
+                        expected: {
+                            amountPool: 200 + 10,
+                            baseFull: 50 * 10,
+                            quoteFull: 100 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 28,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "between order",
+                        isExactInput: false,
+                        amount: 100 + 50 * 10 + 10,
+                        expected: {
+                            amountPool: 100 + 10,
+                            baseFull: 50 * 10,
+                            quoteFull: 100 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 28,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "all",
+                        isExactInput: true,
+                        amount: 1200 * 10 + 300 * 2 + 10,
+                        expected: {
+                            amountPool: 300 * 2 + 10,
+                            baseFull: 350 * 10,
+                            quoteFull: 1200 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 30,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "all",
+                        isExactInput: false,
+                        amount: 350 * 10 + 300 + 10,
+                        expected: {
+                            amountPool: 300 + 10,
+                            baseFull: 350 * 10,
+                            quoteFull: 1200 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 30,
+                            partialKey: 0,
+                        },
+                    },
+                ],
+            },
+            {
+                title: "complex case short",
+                orders: _.flatten(
+                    _.map(_.range(10), () => {
+                        return [
+                            {
+                                isBid: true,
+                                base: 50,
+                                priceX96: Q96.div(2), // amm 50
+                            },
+                            {
+                                isBid: true,
+                                base: 100,
+                                priceX96: Q96.div(4), // amm 75
+                            },
+                            {
+                                isBid: true,
+                                base: 200,
+                                priceX96: Q96.div(8), // amm 87
+                            },
+                        ]
+                    }),
+                ),
+                isBaseToQuote: true,
+                tests: [
+                    {
+                        title: "zero",
+                        isExactInput: true,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "zero",
+                        isExactInput: false,
+                        amount: 0,
+                        expected: {
+                            amountPool: 0,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "amm only",
+                        isExactInput: true,
+                        amount: 50,
+                        expected: {
+                            amountPool: 50,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "amm only",
+                        isExactInput: false,
+                        amount: 100,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 0,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "partial",
+                        isExactInput: true,
+                        amount: 50 + 10,
+                        expected: {
+                            amountPool: 50,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 10,
+                            quotePartial: 5,
+                            fullLastKey: 0,
+                            partialKey: 1,
+                        },
+                    },
+                    {
+                        title: "partial",
+                        isExactInput: false,
+                        amount: 100 + 10,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 0,
+                            quoteFull: 0,
+                            basePartial: 20,
+                            quotePartial: 10,
+                            fullLastKey: 0,
+                            partialKey: 1,
+                        },
+                    },
+                    {
+                        title: "full and partial",
+                        isExactInput: true,
+                        amount: 50 + 50 + 10,
+                        expected: {
+                            amountPool: 50,
+                            baseFull: 50,
+                            quoteFull: 25,
+                            basePartial: 10,
+                            quotePartial: 5,
+                            fullLastKey: 1,
+                            partialKey: 4,
+                        },
+                    },
+                    {
+                        title: "full and partial",
+                        isExactInput: false,
+                        amount: 100 + 25 + 10,
+                        expected: {
+                            amountPool: 100,
+                            baseFull: 50,
+                            quoteFull: 25,
+                            basePartial: 20,
+                            quotePartial: 10,
+                            fullLastKey: 1,
+                            partialKey: 4,
+                        },
+                    },
+                    {
+                        title: "between order",
+                        isExactInput: true,
+                        amount: 50 + 50 * 10 + 10,
+                        expected: {
+                            amountPool: 50 + 10,
+                            baseFull: 50 * 10,
+                            quoteFull: 25 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 28,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "between order",
+                        isExactInput: false,
+                        amount: 100 + 25 * 10 + 10,
+                        expected: {
+                            amountPool: 100 + 10,
+                            baseFull: 50 * 10,
+                            quoteFull: 25 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 28,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "all",
+                        isExactInput: true,
+                        amount: 350 * 10 + 87 + 10,
+                        expected: {
+                            amountPool: 87 + 10,
+                            baseFull: 350 * 10,
+                            quoteFull: 75 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 30,
+                            partialKey: 0,
+                        },
+                    },
+                    {
+                        title: "all",
+                        isExactInput: false,
+                        amount: 75 * 10 + 87 * 2 + 10,
+                        expected: {
+                            amountPool: 87 * 2 + 10,
+                            baseFull: 350 * 10,
+                            quoteFull: 75 * 10,
+                            basePartial: 0,
+                            quotePartial: 0,
+                            fullLastKey: 30,
+                            partialKey: 0,
+                        },
+                    },
+                ],
+            },
         ].forEach(test => {
             describe(test.title, () => {
                 test.tests.forEach(subtest => {
-                    describe(subtest.title + subtest.isExactInput ? " exact input" : " exact output", () => {
+                    describe(subtest.title + (subtest.isExactInput ? " exact input" : " exact output"), () => {
                         it("ok", async () => {
                             await library.createOrders(test.orders)
                             const result = await library.previewSwap(
@@ -96,7 +549,7 @@ describe("OrderBookLibrary previewSwap", () => {
                                 Q96,
                             )
                             _.each(subtest.expected, (_value, key) => {
-                                expect(result[key]).to.deep.eq(subtest.expected[key])
+                                expect(result[key]).to.deep.eq(subtest.expected[key], key)
                             })
                         })
                     })

--- a/test/perpdexExchange/constructor.test.ts
+++ b/test/perpdexExchange/constructor.test.ts
@@ -6,6 +6,7 @@ import { createPerpdexExchangeFixture } from "./fixtures"
 describe("PerpdexExchange constructor", () => {
     let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
     let fixture
+    let factory
 
     let USDC: TestERC20
     const invalidAddress = "0x0000000000000000000000000000000000000001"
@@ -13,21 +14,25 @@ describe("PerpdexExchange constructor", () => {
     beforeEach(async () => {
         fixture = await loadFixture(createPerpdexExchangeFixture({ linear: true }))
         USDC = fixture.USDC
+
+        factory = await ethers.getContractFactory("PerpdexExchange", {
+            libraries: {
+                AccountLibrary: fixture.accountLibrary.address,
+                MakerOrderBookLibrary: fixture.makerOrderBookLibrary.address,
+            },
+        })
     })
 
     describe("constructor", () => {
         it("zero", async () => {
-            const factory = await ethers.getContractFactory("PerpdexExchange")
             await expect(factory.deploy(hre.ethers.constants.AddressZero)).not.to.reverted
         })
 
         it("erc20", async () => {
-            const factory = await ethers.getContractFactory("PerpdexExchange")
             await expect(factory.deploy(USDC.address)).not.to.reverted
         })
 
         it("invalid", async () => {
-            const factory = await ethers.getContractFactory("PerpdexExchange")
             await expect(factory.deploy(invalidAddress)).to.revertedWith("PE_C: token address invalid")
         })
     })

--- a/test/perpdexMarket/constructor.test.ts
+++ b/test/perpdexMarket/constructor.test.ts
@@ -10,6 +10,7 @@ describe("PerpdexMarket constructor", () => {
 
     let priceFeed: MockContract
     let exchange: Wallet
+    let factory
     const symbol = "test"
     const invalidAddress = "0x0000000000000000000000000000000000000001"
 
@@ -17,11 +18,15 @@ describe("PerpdexMarket constructor", () => {
         fixture = await loadFixture(createPerpdexMarketFixture())
         priceFeed = fixture.priceFeed
         exchange = fixture.alice
+        factory = await ethers.getContractFactory("PerpdexMarket", {
+            libraries: {
+                OrderBookLibrary: fixture.orderBookLibrary.address,
+            },
+        })
     })
 
     describe("constructor", () => {
         it("zero", async () => {
-            const factory = await ethers.getContractFactory("PerpdexMarket")
             await expect(
                 factory.deploy(
                     symbol,
@@ -33,19 +38,16 @@ describe("PerpdexMarket constructor", () => {
         })
 
         it("contract", async () => {
-            const factory = await ethers.getContractFactory("PerpdexMarket")
             await expect(factory.deploy(symbol, exchange.address, priceFeed.address, priceFeed.address)).not.to.reverted
         })
 
         it("invalid base", async () => {
-            const factory = await ethers.getContractFactory("PerpdexMarket")
             await expect(
                 factory.deploy(symbol, exchange.address, invalidAddress, hre.ethers.constants.AddressZero),
             ).to.revertedWith("PM_C: base price feed invalid")
         })
 
         it("invalid quote", async () => {
-            const factory = await ethers.getContractFactory("PerpdexMarket")
             await expect(
                 factory.deploy(symbol, exchange.address, hre.ethers.constants.AddressZero, invalidAddress),
             ).to.revertedWith("PM_C: quote price feed invalid")

--- a/test/perpdexMarket/limitOrder.test.ts
+++ b/test/perpdexMarket/limitOrder.test.ts
@@ -1,0 +1,93 @@
+import { expect } from "chai"
+import { waffle } from "hardhat"
+import { PerpdexMarket } from "../../typechain"
+import { createPerpdexMarketFixture } from "./fixtures"
+import { BigNumber, BigNumberish, Wallet } from "ethers"
+import { MockContract } from "ethereum-waffle"
+
+describe("PerpdexMarket limitOrder", () => {
+    let loadFixture = waffle.createFixtureLoader(waffle.provider.getWallets())
+    let fixture
+
+    let market: PerpdexMarket
+    let owner: Wallet
+    let alice: Wallet
+    let exchange: Wallet
+    let priceFeed: MockContract
+
+    const Q96 = BigNumber.from(2).pow(96)
+
+    beforeEach(async () => {
+        fixture = await loadFixture(createPerpdexMarketFixture())
+        market = fixture.perpdexMarket
+        owner = fixture.owner
+        alice = fixture.alice
+        exchange = fixture.exchange
+        priceFeed = fixture.priceFeed
+
+        await market.connect(owner).setPoolFeeRatio(0)
+        await market.connect(owner).setFundingMaxPremiumRatio(0)
+        await market.connect(owner).setPriceLimitConfig({
+            normalOrderRatio: 1e5,
+            liquidationRatio: 2e5,
+            emaNormalOrderRatio: 5e5,
+            emaLiquidationRatio: 5e5,
+            emaSec: 0,
+        })
+    })
+
+    describe("createLimitOrder", () => {
+        it("normal", async () => {
+            await expect(market.connect(exchange).createLimitOrder(true, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(true, 1, Q96, 1)
+            await expect(market.connect(exchange).createLimitOrder(false, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(false, 1, Q96, 1)
+        })
+
+        it("multiple", async () => {
+            await expect(market.connect(exchange).createLimitOrder(true, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(true, 1, Q96, 1)
+            await expect(market.connect(exchange).createLimitOrder(true, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(true, 1, Q96, 2)
+            await expect(market.connect(exchange).createLimitOrder(false, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(false, 1, Q96, 1)
+            await expect(market.connect(exchange).createLimitOrder(false, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(false, 1, Q96, 2)
+        })
+    })
+
+    describe("cancelLimitOrder", () => {
+        it("normal", async () => {
+            await expect(market.connect(exchange).createLimitOrder(true, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(true, 1, Q96, 1)
+            await expect(market.connect(exchange).cancelLimitOrder(true, 1))
+                .to.emit(market, "LimitOrderCanceled")
+                .withArgs(true, 1)
+        })
+
+        it("empty", async () => {
+            await expect(market.connect(exchange).cancelLimitOrder(true, 1)).to.revertedWith("OBL_IE: not exist")
+        })
+
+        it("different side ask", async () => {
+            await expect(market.connect(exchange).createLimitOrder(true, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(true, 1, Q96, 1)
+            await expect(market.connect(exchange).cancelLimitOrder(false, 1)).to.revertedWith("OBL_IE: not exist")
+        })
+
+        it("different side bid", async () => {
+            await expect(market.connect(exchange).createLimitOrder(false, 1, Q96))
+                .to.emit(market, "LimitOrderCreated")
+                .withArgs(false, 1, Q96, 1)
+            await expect(market.connect(exchange).cancelLimitOrder(true, 1)).to.revertedWith("OBL_IE: not exist")
+        })
+    })
+})

--- a/test/takerLibrary/fixtures.ts
+++ b/test/takerLibrary/fixtures.ts
@@ -10,7 +10,14 @@ interface TakerLibraryFixture {
 
 export function createTakerLibraryFixture(): (wallets, provider) => Promise<TakerLibraryFixture> {
     return async ([owner], provider): Promise<TakerLibraryFixture> => {
-        const factory = await ethers.getContractFactory("TestTakerLibrary")
+        const accountLibraryFactory = await ethers.getContractFactory("AccountLibrary")
+        const accountLibrary = await accountLibraryFactory.deploy()
+
+        const factory = await ethers.getContractFactory("TestTakerLibrary", {
+            libraries: {
+                AccountLibrary: accountLibrary.address,
+            },
+        })
         const takerLibrary = (await factory.deploy()) as TestTakerLibrary
 
         const market = await waffle.deployMockContract(owner, IPerpdexMarketJson.abi)

--- a/test/takerLibrary/swapWithProtocolFee.test.ts
+++ b/test/takerLibrary/swapWithProtocolFee.test.ts
@@ -74,9 +74,12 @@ describe("TakerLibrary", () => {
             },
         ].forEach(test => {
             it(test.title, async () => {
-                await market.mock.swap
-                    .withArgs(test.isBaseToQuote, test.isExactInput, test.swapAmount, false)
-                    .returns(test.swapOppositeAmount)
+                await market.mock.swap.withArgs(test.isBaseToQuote, test.isExactInput, test.swapAmount, false).returns({
+                    oppositeAmount: test.swapOppositeAmount,
+                    basePartial: 0,
+                    quotePartial: 0,
+                    partialKey: 0,
+                })
 
                 await library.setProtocolInfo({ protocolFee: test.protocolFeeBalance })
 


### PR DESCRIPTION
changes

- added limit order interfaces
  - createLimitOrder
  - cancelLimitOrder
- implement limit order    
- reduce contract size
  - use external libraries
  - modifier optimization 

limit order specs

- post only
- can match in same block (for simplicity)
- matching is done in hybrid along with amm
- all operations require O(logN) gas (N: limit order count)

todo

- max order count
- reconsider specs and interfaces
- refactor (too messy)
- write test (coverage 100%)
- measure gas

## impl details

### hybrid liquidity (amm + order book)

- Taker orders match AMM and order book simultaneously
- Done by search using red black tree
- see OrderBookLibrary.sol for more information

### lazy execution

- O(logN) matching by red black tree bulk remove
- Lazy execution is performed the next time the maker performs any operations
  - Order of execution is represented by executionId
  - The executionId is stored in the root of the subtree removed by bulk remove.
  - This allows you to reproduce the order of execution and the information at the time of execution at a later time.
- Each trader has his own order-only red black tree separate from the whole
  - You can determine if the order has been executed or not by starting from the order close to the best and terminating when you reach the order that has not been executed.  
  - This should almost always end with just looking at the first one order

### partial execution

- Partially executed orders are processed immediately.
  - Otherwise, partial executions can occur an arbitrary number of times for a single order, which would arbitrarily increase the computation of lazy execution.
- perform lazy execution before partial execution
